### PR TITLE
feat: add legal pages and expand footer with app, resource, and legal links

### DIFF
--- a/src/components/footer/FooterBox.tsx
+++ b/src/components/footer/FooterBox.tsx
@@ -27,6 +27,18 @@ const FooterBox: React.FC = () => {
 
         <div className="flex items-center gap-1">
           <Link
+            href="/terms"
+            className="rounded-lg px-3 py-2 font-mono text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            Terms
+          </Link>
+          <Link
+            href="/privacy"
+            className="rounded-lg px-3 py-2 font-mono text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            Privacy
+          </Link>
+          <Link
             href="/contact"
             className="rounded-lg px-3 py-2 font-mono text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           >

--- a/src/components/footer/FooterBox.tsx
+++ b/src/components/footer/FooterBox.tsx
@@ -2,60 +2,104 @@ import Link from 'next/link'
 import React from 'react'
 import { LockIcon, ExternalLinkIcon } from '../icons/ChakraIcons'
 
-const footerLinks = [
+interface FooterItem {
+  name: string
+  href: string
+  external?: boolean
+}
+
+interface FooterColumn {
+  title: string
+  items: FooterItem[]
+}
+
+const footerColumns: FooterColumn[] = [
   {
-    name: 'Review contract code',
-    href: 'https://github.com/marc-aurele-besner/mymultisig-contract'
+    title: 'App',
+    items: [
+      { name: 'Create a multisig', href: '/createMultiSig' },
+      { name: 'Import a multisig', href: '/importMultiSig' },
+      { name: 'Open existing multisig', href: '/useYourMultiSig' },
+      { name: 'Integration', href: '/integration' },
+      { name: 'About', href: '/about' }
+    ]
   },
   {
-    name: 'Review app code',
-    href: 'https://github.com/marc-aurele-besner/mymultisig-app'
+    title: 'Resources',
+    items: [
+      { name: 'App code', href: 'https://github.com/marc-aurele-besner/mymultisig-app', external: true },
+      { name: 'Contract code', href: 'https://github.com/marc-aurele-besner/mymultisig-contract', external: true },
+      { name: 'npm package', href: 'https://www.npmjs.com/package/mymultisig-contract', external: true },
+      { name: 'Report an issue', href: 'https://github.com/marc-aurele-besner/mymultisig-app/issues', external: true }
+    ]
+  },
+  {
+    title: 'Legal & support',
+    items: [
+      { name: 'Terms & Conditions', href: '/terms' },
+      { name: 'Privacy Policy', href: '/privacy' },
+      { name: 'Contact', href: '/contact' }
+    ]
   }
 ]
 
 const FooterBox: React.FC = () => {
   return (
     <footer className="relative z-[1] w-full border-t border-border">
-      <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-4 px-4 py-6 md:px-6">
-        <div className="flex items-center gap-2.5">
-          <span className="flex h-6 w-6 items-center justify-center rounded-md bg-primary/15 text-primary">
-            <LockIcon className="h-3.5 w-3.5" />
-          </span>
-          <span className="font-display text-sm font-bold tracking-tight text-foreground">MyMultiSig.app</span>
-          <span className="font-mono text-xs text-muted-foreground">© {new Date().getFullYear()}</span>
+      <div className="pointer-events-none absolute left-[10%] right-[10%] top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
+
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 md:px-6 md:py-12">
+        <div className="grid grid-cols-2 gap-8 md:grid-cols-[2fr_1fr_1fr_1fr] md:gap-6">
+          <div className="col-span-2 flex flex-col gap-3 md:col-span-1 md:pr-8">
+            <div className="flex items-center gap-2.5">
+              <span className="flex h-6 w-6 items-center justify-center rounded-md bg-primary/15 text-primary">
+                <LockIcon className="h-3.5 w-3.5" />
+              </span>
+              <span className="font-display text-sm font-bold tracking-tight text-foreground">MyMultiSig.app</span>
+            </div>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Open-source, non-custodial multisig wallets on 15+ EVM chains. Your keys, your cosigners, your rules.
+            </p>
+          </div>
+
+          {footerColumns.map((column) => (
+            <nav key={column.title} aria-label={column.title} className="flex flex-col gap-3">
+              <h3 className="font-mono text-xs uppercase tracking-wider text-muted-foreground/70">{column.title}</h3>
+              <ul className="flex flex-col gap-2">
+                {column.items.map((item) => (
+                  <li key={item.href}>
+                    {item.external ? (
+                      <a
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                      >
+                        {item.name}
+                        <ExternalLinkIcon boxSize={12} className="shrink-0" />
+                      </a>
+                    ) : (
+                      <Link
+                        href={item.href}
+                        className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                      >
+                        {item.name}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          ))}
         </div>
 
-        <div className="flex items-center gap-1">
-          <Link
-            href="/terms"
-            className="rounded-lg px-3 py-2 font-mono text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          >
-            Terms
-          </Link>
-          <Link
-            href="/privacy"
-            className="rounded-lg px-3 py-2 font-mono text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          >
-            Privacy
-          </Link>
-          <Link
-            href="/contact"
-            className="rounded-lg px-3 py-2 font-mono text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          >
-            Contact
-          </Link>
-          {footerLinks.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1.5 rounded-lg px-3 py-2 font-mono text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            >
-              {item.name}
-              <ExternalLinkIcon boxSize={12} className="shrink-0" />
-            </Link>
-          ))}
+        <div className="mt-10 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-6">
+          <span className="font-mono text-xs text-muted-foreground">
+            © {new Date().getFullYear()} MyMultiSig.app
+          </span>
+          <span className="font-mono text-xs text-muted-foreground/70">
+            Non-custodial — this app never holds your keys or funds.
+          </span>
         </div>
       </div>
     </footer>

--- a/src/components/footer/FooterBox.tsx
+++ b/src/components/footer/FooterBox.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import React from 'react'
-import { LockIcon, ExternalLinkIcon } from '../icons/ChakraIcons'
+import Image from 'next/image'
+import { ExternalLinkIcon } from '../icons/ChakraIcons'
 
 interface FooterItem {
   name: string
@@ -52,9 +53,13 @@ const FooterBox: React.FC = () => {
         <div className="grid grid-cols-2 gap-8 md:grid-cols-[2fr_1fr_1fr_1fr] md:gap-6">
           <div className="col-span-2 flex flex-col gap-3 md:col-span-1 md:pr-8">
             <div className="flex items-center gap-2.5">
-              <span className="flex h-6 w-6 items-center justify-center rounded-md bg-primary/15 text-primary">
-                <LockIcon className="h-3.5 w-3.5" />
-              </span>
+              <Image
+                src="/favicon/favicon-96x96.png"
+                alt="MyMultiSig.app"
+                width={24}
+                height={24}
+                className="h-6 w-6 rounded-md"
+              />
               <span className="font-display text-sm font-bold tracking-tight text-foreground">MyMultiSig.app</span>
             </div>
             <p className="text-sm leading-relaxed text-muted-foreground">

--- a/src/components/views/Privacy.stories.tsx
+++ b/src/components/views/Privacy.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import Privacy from './Privacy'
+
+const meta: Meta<typeof Privacy> = {
+  title: 'Views/Privacy',
+  component: Privacy,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof Privacy> = () => <Privacy />

--- a/src/components/views/Privacy.tsx
+++ b/src/components/views/Privacy.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import Link from 'next/link'
+import BigCard from '../cards/BigCard'
+
+const LAST_UPDATED = 'July 14, 2026'
+
+const sections = [
+  {
+    title: '1. Overview',
+    paragraphs: [
+      'MyMultiSig.app is a non-custodial, open-source interface for multisignature smart contracts. We collect as little personal information as possible: no account registration is required, and we never have access to your private keys or funds.'
+    ]
+  },
+  {
+    title: '2. Information we store',
+    paragraphs: [
+      'Wallet addresses and multisig configuration. When you create or import a multisig, its address, name, chain, signer addresses, and threshold are stored in our database so the App can display your wallets across devices.',
+      'Transaction requests. Proposed transactions and their collected signatures are stored in our database until they are executed or discarded.',
+      'Sign-In with Ethereum sessions. When you sign in, a session cookie tied to your wallet address is set so the App can authorize writes to our database. The cookie contains no personal information beyond your public wallet address.',
+      'Contact form submissions. If you use the contact form, the name, email address, and message you provide are emailed to us so we can respond.'
+    ]
+  },
+  {
+    title: '3. Data stored on your device',
+    paragraphs: [
+      'The App keeps state in your browser’s local storage: your added contracts and multisigs, your selected multisig, your theme preference, and whether you have accepted the disclaimer. This data never leaves your device unless you take an action that sends it to our database, and you can clear it at any time through your browser settings.'
+    ]
+  },
+  {
+    title: '4. Analytics',
+    paragraphs: [
+      'We use Google Analytics to understand aggregate usage of the App (pages visited, approximate location, device type). Google Analytics sets cookies and processes data under its own privacy policy. You can block it with standard browser tools or extensions without affecting the App’s functionality.'
+    ]
+  },
+  {
+    title: '5. Third-party services',
+    paragraphs: [
+      'The App relies on third-party infrastructure that may process your IP address and request metadata under their own privacy policies: Netlify (hosting), Neon (database), WalletConnect (wallet connections), RPC providers such as Alchemy, Infura, or public endpoints (blockchain reads and writes), Resend (contact form email delivery), and Google Analytics (usage analytics).'
+    ]
+  },
+  {
+    title: '6. On-chain data',
+    paragraphs: [
+      'Anything you write to a public blockchain — multisig deployments, signer sets, executed transactions — is public, permanent, and outside of our control. This policy cannot apply to on-chain data.'
+    ]
+  },
+  {
+    title: '7. Data retention and removal',
+    paragraphs: [
+      'Multisig and transaction data remains in our database so that all signers can access it. If you want data associated with your wallet removed, contact us and we will delete what we reasonably can, keeping in mind that other signers may depend on shared multisig records and that on-chain data cannot be deleted.'
+    ]
+  },
+  {
+    title: '8. Changes to this policy',
+    paragraphs: [
+      'We may update this policy from time to time. The "Last updated" date at the top of this page reflects the most recent revision.'
+    ]
+  }
+]
+
+const Privacy: React.FC = () => {
+  return (
+    <div className="flex justify-center">
+      <BigCard className="max-w-[900px]">
+        <div className="flex w-full flex-col gap-8 py-4 md:py-8">
+          <div>
+            <h1 className="font-display mb-2 text-3xl font-extrabold tracking-tight md:text-4xl">
+              <span className="bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent">
+                Privacy Policy
+              </span>
+            </h1>
+            <p className="font-mono text-xs text-muted-foreground">Last updated: {LAST_UPDATED}</p>
+          </div>
+
+          {sections.map((section) => (
+            <section key={section.title} className="flex flex-col gap-3">
+              <h2 className="text-lg font-semibold text-foreground">{section.title}</h2>
+              {section.paragraphs.map((paragraph, index) => (
+                <p key={index} className="text-sm leading-relaxed text-muted-foreground">
+                  {paragraph}
+                </p>
+              ))}
+            </section>
+          ))}
+
+          <section className="flex flex-col gap-3">
+            <h2 className="text-lg font-semibold text-foreground">9. Contact</h2>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Questions about this policy or a data removal request? Reach out through the{' '}
+              <Link href="/contact" className="text-primary underline-offset-4 hover:underline">
+                contact page
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+      </BigCard>
+    </div>
+  )
+}
+
+export default Privacy

--- a/src/components/views/Terms.stories.tsx
+++ b/src/components/views/Terms.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import Terms from './Terms'
+
+const meta: Meta<typeof Terms> = {
+  title: 'Views/Terms',
+  component: Terms,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof Terms> = () => <Terms />

--- a/src/components/views/Terms.tsx
+++ b/src/components/views/Terms.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import Link from 'next/link'
+import BigCard from '../cards/BigCard'
+
+const LAST_UPDATED = 'July 14, 2026'
+
+const sections = [
+  {
+    title: '1. Acceptance of these terms',
+    paragraphs: [
+      'By accessing or using MyMultiSig.app (the "App"), you agree to be bound by these Terms & Conditions. If you do not agree, do not use the App.'
+    ]
+  },
+  {
+    title: '2. The service',
+    paragraphs: [
+      'MyMultiSig.app is an open-source interface for deploying and interacting with multisignature smart contracts on public blockchains. The App is non-custodial: it never holds your funds, private keys, or seed phrases. All transactions are signed by your own wallet and executed on-chain by the networks you choose.',
+      'This is an early-stage project. The smart contracts are open-source and available for review but have not been professionally audited. Features may be incomplete or may not function as intended.'
+    ]
+  },
+  {
+    title: '3. Your responsibilities',
+    paragraphs: [
+      'You are solely responsible for safeguarding your wallet, private keys, and recovery phrases. You are responsible for reviewing and verifying every transaction, signer address, and threshold configuration before signing or executing it. Transactions on public blockchains are irreversible.',
+      'You are responsible for complying with the laws and regulations that apply to you in your jurisdiction, including any restrictions on the use of blockchain-based services.'
+    ]
+  },
+  {
+    title: '4. No warranty',
+    paragraphs: [
+      'The App and the associated smart contracts are provided "as is" and "as available", without warranties of any kind, express or implied, including warranties of merchantability, fitness for a particular purpose, and non-infringement. We do not guarantee that the App will be uninterrupted, error-free, or secure.'
+    ]
+  },
+  {
+    title: '5. Limitation of liability',
+    paragraphs: [
+      'To the maximum extent permitted by law, the authors and contributors of MyMultiSig.app shall not be liable for any direct, indirect, incidental, special, consequential, or exemplary damages — including loss of funds, tokens, data, or profits — arising from your use of, or inability to use, the App or the smart contracts it interacts with.'
+    ]
+  },
+  {
+    title: '6. Fees',
+    paragraphs: [
+      'The App does not charge fees. Interacting with smart contracts requires network (gas) fees, which are paid to the relevant blockchain network and are outside of our control.'
+    ]
+  },
+  {
+    title: '7. Changes to these terms',
+    paragraphs: [
+      'We may update these Terms & Conditions from time to time. The "Last updated" date at the top of this page reflects the most recent revision. Continued use of the App after changes take effect constitutes acceptance of the revised terms.'
+    ]
+  }
+]
+
+const Terms: React.FC = () => {
+  return (
+    <div className="flex justify-center">
+      <BigCard className="max-w-[900px]">
+        <div className="flex w-full flex-col gap-8 py-4 md:py-8">
+          <div>
+            <h1 className="font-display mb-2 text-3xl font-extrabold tracking-tight md:text-4xl">
+              <span className="bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent">
+                Terms &amp; Conditions
+              </span>
+            </h1>
+            <p className="font-mono text-xs text-muted-foreground">Last updated: {LAST_UPDATED}</p>
+          </div>
+
+          {sections.map((section) => (
+            <section key={section.title} className="flex flex-col gap-3">
+              <h2 className="text-lg font-semibold text-foreground">{section.title}</h2>
+              {section.paragraphs.map((paragraph, index) => (
+                <p key={index} className="text-sm leading-relaxed text-muted-foreground">
+                  {paragraph}
+                </p>
+              ))}
+            </section>
+          ))}
+
+          <section className="flex flex-col gap-3">
+            <h2 className="text-lg font-semibold text-foreground">8. Contact</h2>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Questions about these terms? Reach out through the{' '}
+              <Link href="/contact" className="text-primary underline-offset-4 hover:underline">
+                contact page
+              </Link>{' '}
+              or open an issue on{' '}
+              <a
+                href="https://github.com/marc-aurele-besner/mymultisig-app"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                GitHub
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </BigCard>
+    </div>
+  )
+}
+
+export default Terms

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import Privacy from '../components/views/Privacy'
+
+const Page: React.FC = () => {
+  return <Privacy />
+}
+
+export async function getStaticProps() {
+  return { props: { title: 'MyMultiSig - Privacy Policy' } }
+}
+
+export default Page

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import Terms from '../components/views/Terms'
+
+const Page: React.FC = () => {
+  return <Terms />
+}
+
+export async function getStaticProps() {
+  return { props: { title: 'MyMultiSig - Terms & Conditions' } }
+}
+
+export default Page


### PR DESCRIPTION
## Summary
- Add a **Terms & Conditions** page at `/terms` and a **Privacy Policy** page at `/privacy`, each as a view component (`src/components/views/Terms.tsx`, `Privacy.tsx`) with Storybook stories, following the existing About/Contact page pattern (BigCard layout, SSG via `getStaticProps`).
- Redesign the footer from a single link row into a multi-column layout: brand column with a one-line description, plus **App** (create/import/open multisig, integration, about), **Resources** (app & contract repos, npm package, issue tracker), and **Legal & support** (terms, privacy, contact) columns, the BigCard ember hairline along the top edge, and a bottom bar with the copyright and a non-custodial note.

## Content notes
The legal copy is grounded in what the app actually does:
- Terms mirror the existing disclaimer modal: non-custodial, open-source, early-stage/unaudited contracts, no warranty, user responsibility for keys and transaction review.
- Privacy policy discloses the real data flows: multisig/transaction data in Neon, SIWE session cookies, Zustand localStorage state, Google Analytics, and third-party infrastructure (Netlify, WalletConnect, RPC providers, Resend).

## Testing
- `yarn build` passes; `/terms` and `/privacy` prerender as SSG pages.
- Footer verified headlessly with Playwright screenshots at desktop (1280px) and mobile (390px) widths.
- No new Prettier failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)