### PR TITLE
feat: UI/UX polish and purposeful motion across the app

### DIFF
--- a/src/components/cards/ConfirmationCard.tsx
+++ b/src/components/cards/ConfirmationCard.tsx
@@ -2,6 +2,7 @@ import React, { Fragment, useEffect } from 'react'
 import Link from 'next/link'
 import { useChainId, useChains } from 'wagmi'
 import { Button } from '@/components/ui/button'
+import { LoadingDots } from '@/components/ui/loading-dots'
 import { CheckCircleIcon, ExternalLinkIcon, SettingsIcon, AddIcon } from '../icons/ChakraIcons'
 
 import useConfirmation from '../../hooks/useConfirmation'
@@ -44,9 +45,8 @@ const ConfirmationWithEventDetailCard: React.FC<ConfirmationDetailProps> = ({
 
   if (!multiSigAddress) {
     return (
-      <div className='flex items-center justify-center gap-3 rounded-xl border border-border bg-muted/30 p-4'>
-        <span className='h-3 w-3 animate-pulse rounded-full bg-primary' />
-        <span className='text-sm text-muted-foreground'>Waiting for the wallet address on-chain...</span>
+      <div className='flex items-center justify-center rounded-xl border border-border bg-muted/30 p-4'>
+        <LoadingDots label='Waiting for the wallet address on-chain...' />
       </div>
     )
   }
@@ -93,19 +93,16 @@ const ConfirmationCard: React.FC<ConfirmationCardProps> = ({ hash, multiSigFacto
   return (
     <Fragment>
       {isLoading && (
-        <div className='flex items-center justify-center gap-3 rounded-xl border border-border bg-muted/30 p-4'>
-          <span className='h-3 w-3 animate-pulse rounded-full bg-primary' />
-          <span className='text-sm text-muted-foreground'>Waiting for the deployment to confirm...</span>
+        <div className='flex items-center justify-center rounded-xl border border-border bg-muted/30 p-4'>
+          <LoadingDots label='Waiting for the deployment to confirm...' />
         </div>
       )}
       {error && <p className='text-sm font-semibold text-destructive'>Error: {error.message}</p>}
       {isSuccess && (
         <Fragment>
           <div className='flex items-center gap-2'>
-            <CheckCircleIcon className='h-5 w-5 text-green-500' />
-            <p className='text-lg font-bold text-green-600 dark:text-green-400'>
-              Your multisig contract has been deployed!
-            </p>
+            <CheckCircleIcon className='h-5 w-5 animate-pop-in text-primary' />
+            <p className='text-lg font-bold text-foreground'>Your multisig contract has been deployed!</p>
           </div>
           <ConfirmationWithEventDetailCard
             hash={hash}

--- a/src/components/cards/ImportConfirmationCard.tsx
+++ b/src/components/cards/ImportConfirmationCard.tsx
@@ -2,6 +2,7 @@ import React, { Fragment, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useChainId, useChains } from 'wagmi'
 import { Button } from '@/components/ui/button'
+import { LoadingDots } from '@/components/ui/loading-dots'
 import { CheckCircleIcon, SettingsIcon, DownloadIcon } from '../icons/ChakraIcons'
 
 import useMultiSigDetails from '../../hooks/useMultiSigDetails'
@@ -67,17 +68,16 @@ const ImportConfirmationCard: React.FC<ImportConfirmationCardProps> = ({
   return (
     <Fragment>
       {isLoading && (
-        <div className='flex items-center justify-center gap-3 rounded-xl border border-border bg-muted/30 p-4'>
-          <span className='h-3 w-3 animate-pulse rounded-full bg-primary' />
-          <span className='text-sm text-muted-foreground'>Reading the multisig contract...</span>
+        <div className='flex items-center justify-center rounded-xl border border-border bg-muted/30 p-4'>
+          <LoadingDots label='Reading the multisig contract...' />
         </div>
       )}
       {error && <p className='text-sm font-semibold text-destructive'>Error: {error.message}</p>}
       {isSuccess && imported && (
         <div className='flex w-full flex-col gap-4'>
           <div className='flex items-center gap-2'>
-            <CheckCircleIcon className='h-5 w-5 text-green-500' />
-            <p className='text-lg font-bold text-green-600 dark:text-green-400'>
+            <CheckCircleIcon className='h-5 w-5 animate-pop-in text-primary' />
+            <p className='text-lg font-bold text-foreground'>
               Your {walletType === 'extended' ? 'Extended ' : ''}multisig has been imported!
             </p>
           </div>

--- a/src/components/dom/Layout.tsx
+++ b/src/components/dom/Layout.tsx
@@ -17,7 +17,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           className="absolute inset-x-0 top-0 h-[60vh]"
           style={{
             background:
-              'radial-gradient(ellipse 90% 90% at 50% -25%, color-mix(in oklab, var(--primary) 13%, transparent), transparent 70%)'
+              'radial-gradient(ellipse 90% 90% at 50% -25%, color-mix(in oklab, var(--primary) 13%, transparent), transparent 70%)',
+            animation: 'ember-breathe 7s ease-in-out infinite alternate',
+            transformOrigin: 'top center'
           }}
         />
         <div

--- a/src/components/forms/CreateMultiSigForm.tsx
+++ b/src/components/forms/CreateMultiSigForm.tsx
@@ -4,6 +4,7 @@ import { ExternalLinkIcon, CheckCircleIcon, AddIcon, DeleteIcon, ArrowBackIcon }
 import { motion } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
+import { LoadingDots } from '@/components/ui/loading-dots'
 import { cn } from '@/lib/utils'
 
 import TextInput from '../inputs/TextInput'
@@ -380,7 +381,7 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
               className='w-full rounded-xl border border-primary bg-primary/10 p-4'
             >
               <div className='flex items-center justify-center gap-3'>
-                <span className='h-3 w-3 animate-pulse rounded-full bg-primary' />
+                <LoadingDots />
                 <span className='text-sm font-medium text-primary'>
                   Please confirm the transaction in your wallet...
                 </span>

--- a/src/components/forms/CreateMultiSigForm.tsx
+++ b/src/components/forms/CreateMultiSigForm.tsx
@@ -129,11 +129,11 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
     return (
       <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className='w-full'>
         <div className='flex flex-col gap-4'>
-          <div className='w-full rounded-xl border border-green-500/50 bg-green-500/10 p-4'>
+          <div className='w-full rounded-xl border border-primary/50 bg-primary/10 p-4'>
             <div className='flex items-center gap-3'>
-              <CheckCircleIcon className='h-5 w-5 text-green-500' />
+              <CheckCircleIcon className='h-5 w-5 animate-pop-in text-primary' />
               <div className='flex flex-col gap-0'>
-                <span className='text-sm font-semibold text-green-600 dark:text-green-400'>Transaction submitted</span>
+                <span className='text-sm font-semibold text-primary'>Transaction submitted</span>
                 <span className='text-xs text-muted-foreground'>
                   Hash: {data.slice(0, 20)}...{data.slice(-10)}
                 </span>

--- a/src/components/forms/DiscoverMultiSigs.tsx
+++ b/src/components/forms/DiscoverMultiSigs.tsx
@@ -44,7 +44,7 @@ const DiscoverMultiSigs: React.FC<DiscoverMultiSigsProps> = ({ factory }) => {
               </span>
             </div>
             {wallet.alreadyImported ? (
-              <span className='text-sm text-green-600 dark:text-green-400'>Imported</span>
+              <span className='font-mono text-xs text-primary'>Imported</span>
             ) : (
               <Button variant='outline' onClick={() => setImporting(wallet.address)}>
                 Import

--- a/src/components/header/HeaderWalletSelector.tsx
+++ b/src/components/header/HeaderWalletSelector.tsx
@@ -80,7 +80,7 @@ export const HeaderWalletSelector: React.FC = () => {
                 Connected with
               </div>
               <div className="mt-1 flex items-center gap-1">
-                <CheckIcon className="h-3 w-3 text-green-500" />
+                <CheckIcon className="h-3 w-3 text-primary" />
                 <span className="text-sm font-medium">{connector.name}</span>
               </div>
             </DropdownMenuLabel>

--- a/src/components/multiSigDetails/ExtendedGovernancePanel.tsx
+++ b/src/components/multiSigDetails/ExtendedGovernancePanel.tsx
@@ -131,7 +131,7 @@ const ExtendedGovernancePanel: React.FC<ExtendedGovernancePanelProps> = ({ multi
           />
           {/^\d+$/.test(nonceToCheck) && nonceUsed != null && (
             <span
-              className={`text-sm font-semibold ${nonceUsed ? 'text-destructive' : 'text-green-600 dark:text-green-400'}`}
+              className={`text-sm font-semibold ${nonceUsed ? 'text-destructive' : 'text-primary'}`}
             >
               Nonce {nonceToCheck} is {nonceUsed ? 'used / burned' : 'available'}
             </span>

--- a/src/components/multiSigDetails/MultiSigActivityFeed.tsx
+++ b/src/components/multiSigDetails/MultiSigActivityFeed.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useChainId, useChains } from 'wagmi'
 import { formatEther } from 'viem'
 import { Button } from '@/components/ui/button'
+import { LoadingDots } from '@/components/ui/loading-dots'
 import { ExternalLinkIcon } from '../icons/ChakraIcons'
 import { cn } from '@/lib/utils'
 
@@ -196,9 +197,8 @@ const MultiSigActivityFeed: React.FC<MultiSigActivityFeedProps> = ({ multiSigAdd
       </div>
 
       {isLoading && (
-        <div className='flex items-center justify-center gap-3 p-2'>
-          <span className='h-3 w-3 animate-pulse rounded-full bg-primary' />
-          <span className='text-sm text-muted-foreground'>Scanning blocks for activity...</span>
+        <div className='flex items-center justify-center p-2'>
+          <LoadingDots label='Scanning blocks for activity...' />
         </div>
       )}
 

--- a/src/components/multiSigDetails/MultiSigHeader.tsx
+++ b/src/components/multiSigDetails/MultiSigHeader.tsx
@@ -60,7 +60,7 @@ const MultiSigHeader: React.FC<MultiSigHeaderProps> = ({ multiSigAddress }) => {
             aria-label='Copy address'
             className='text-muted-foreground transition-colors hover:text-primary'
           >
-            {copied ? <CheckIcon className='h-3.5 w-3.5 text-green-500' /> : <CopyIcon className='h-3.5 w-3.5' />}
+            {copied ? <CheckIcon className='h-3.5 w-3.5 animate-pop-in text-primary' /> : <CopyIcon className='h-3.5 w-3.5' />}
           </button>
           {explorerUrl && (
             <a

--- a/src/components/multiSigDetails/MultiSigNav.tsx
+++ b/src/components/multiSigDetails/MultiSigNav.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
 
 interface MultiSigNavProps {
@@ -17,7 +18,7 @@ const TABS = [
 ] as const
 
 // Shared navigation for every /multisig/[address] subpage so the same tabs
-// appear everywhere, with the current page highlighted.
+// appear everywhere. The active pill slides between tabs via a shared layoutId.
 const MultiSigNav: React.FC<MultiSigNavProps> = ({ multiSigAddress }) => {
   const router = useRouter()
   const activeSlug = router.pathname.split('/multisig/[multisigAddress]')[1]?.replace('/', '') ?? ''
@@ -33,13 +34,18 @@ const MultiSigNav: React.FC<MultiSigNavProps> = ({ multiSigAddress }) => {
               href={`/multisig/${multiSigAddress}${tab.slug === '' ? '' : `/${tab.slug}`}`}
               aria-current={isActive ? 'page' : undefined}
               className={cn(
-                'whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-primary text-primary-foreground shadow-sm'
-                  : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                'relative whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium transition-colors',
+                isActive ? 'text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground'
               )}
             >
-              {tab.label}
+              {isActive && (
+                <motion.span
+                  layoutId='multisig-nav-pill'
+                  className='absolute inset-0 rounded-md bg-primary shadow-sm'
+                  transition={{ type: 'spring', stiffness: 500, damping: 40 }}
+                />
+              )}
+              <span className='relative'>{tab.label}</span>
             </Link>
           )
         })}

--- a/src/components/multiSigDetails/MultiSigOverview.tsx
+++ b/src/components/multiSigDetails/MultiSigOverview.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { useAccount, useBalance, useChainId, useChains } from 'wagmi'
 import { formatEther } from 'viem'
 import { Button } from '@/components/ui/button'
+import { LoadingDots } from '@/components/ui/loading-dots'
 import { cn } from '@/lib/utils'
 import { CoinsIcon } from '../icons/ChakraIcons'
 
@@ -79,9 +80,8 @@ const MultiSigOverview: React.FC<MultiSigOverviewProps> = ({ multiSigAddress }) 
 
   if (multiSigDetails == null)
     return (
-      <div className='flex items-center justify-center gap-3 p-6'>
-        <span className='h-3 w-3 animate-pulse rounded-full bg-primary' />
-        <span className='text-sm text-muted-foreground'>Reading the multisig contract...</span>
+      <div className='flex items-center justify-center p-6'>
+        <LoadingDots label='Reading the multisig contract...' />
       </div>
     )
 
@@ -197,9 +197,8 @@ const MultiSigOverview: React.FC<MultiSigOverviewProps> = ({ multiSigAddress }) 
               />
             ))
           ) : activityLoading ? (
-            <div className='flex items-center gap-3 p-2'>
-              <span className='h-2.5 w-2.5 animate-pulse rounded-full bg-primary' />
-              <span className='text-sm text-muted-foreground'>Scanning recent blocks...</span>
+            <div className='flex items-center p-2'>
+              <LoadingDots size='sm' label='Scanning recent blocks...' />
             </div>
           ) : (
             <p className='text-sm text-muted-foreground'>

--- a/src/components/multiSigDetails/MultiSigOverview.tsx
+++ b/src/components/multiSigDetails/MultiSigOverview.tsx
@@ -46,7 +46,13 @@ const StatTile: React.FC<{
   const tileClass = 'flex flex-col gap-1 rounded-xl border border-border bg-muted/30 p-4'
   if (href != null)
     return (
-      <Link href={href} className={cn(tileClass, 'transition-colors hover:border-primary/50 hover:bg-muted/60')}>
+      <Link
+        href={href}
+        className={cn(
+          tileClass,
+          'transition-[border-color,background-color,transform,box-shadow] duration-200 ease-out hover:-translate-y-0.5 hover:border-primary/50 hover:bg-muted/60 hover:shadow-[0_8px_24px_-16px] hover:shadow-primary/40 motion-reduce:transition-none motion-reduce:hover:translate-y-0'
+        )}
+      >
         {content}
       </Link>
     )

--- a/src/components/multiSigDetails/MultiSigRequestDetail.tsx
+++ b/src/components/multiSigDetails/MultiSigRequestDetail.tsx
@@ -122,7 +122,7 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
                   {result != null && (
                     <span
                       className={`font-semibold ${
-                        result.success ? 'text-green-600 dark:text-green-400' : 'text-destructive'
+                        result.success ? 'text-primary' : 'text-destructive'
                       }`}
                     >
                       {result.success ? 'succeeded' : `failed${result.returnData !== '0x' ? ` (${result.returnData})` : ''}`}
@@ -135,7 +135,7 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
         )}
 
         {requestDetails.isExecuted ? (
-          <div className="px-2 pt-2 text-xl font-bold text-green-600 dark:text-green-400">
+          <div className="px-2 pt-2 text-xl font-bold text-primary">
             This request has been executed
             {requestDetails.dateExecuted != null &&
               ` on the ${new Date(Number(requestDetails.dateExecuted)).toLocaleDateString()}`}
@@ -165,7 +165,7 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
             <div className="flex flex-wrap items-center gap-2">
               <span className="px-2 pt-2 text-xl font-bold text-foreground">Sign this request</span>
               {hasSigned ? (
-                <span className="px-2 pt-2 text-xl font-bold text-green-600 dark:text-green-400">
+                <span className="px-2 pt-2 text-xl font-bold text-primary">
                   You already signed this request
                 </span>
               ) : hasApproved ? (

--- a/src/components/multiSigDetails/MultiSigRequestList.tsx
+++ b/src/components/multiSigDetails/MultiSigRequestList.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
+import { LoadingDots } from '@/components/ui/loading-dots'
 import { AddIcon } from '../icons/ChakraIcons'
 import { MultiSigOnChainData } from '../../models/MultiSigs'
 import useMultiSigRequests from '../../hooks/useMultiSigRequests'
@@ -30,9 +31,8 @@ const MultiSigRequestList: React.FC<MultiSigRequestListProps> = ({ multiSigAddre
 
   if (requests == null || isLoading) {
     return (
-      <div className='flex w-full items-center justify-center gap-3 rounded-xl border border-border bg-muted/30 p-6'>
-        <span className='h-3 w-3 animate-pulse rounded-full bg-primary' />
-        <span className='text-sm text-muted-foreground'>Loading requests...</span>
+      <div className='flex w-full items-center justify-center rounded-xl border border-border bg-muted/30 p-6'>
+        <LoadingDots label='Loading requests...' />
       </div>
     )
   }

--- a/src/components/multiSigDetails/MultiSigRequestList.tsx
+++ b/src/components/multiSigDetails/MultiSigRequestList.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import { motion } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { LoadingDots } from '@/components/ui/loading-dots'
 import { AddIcon } from '../icons/ChakraIcons'
@@ -60,30 +61,48 @@ const MultiSigRequestList: React.FC<MultiSigRequestListProps> = ({ multiSigAddre
 
   return (
     <div className='flex w-full flex-col gap-2'>
-      {requests.map((request) => (
-        <div
-          key={`Request-${request.id}`}
-          className='flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border p-3'
-        >
-          <div className='flex min-w-0 flex-col'>
-            <span className='truncate text-sm font-semibold text-foreground'>{request.description}</span>
-            <span className='text-xs text-muted-foreground'>
-              {request.isExecuted
-                ? 'Executed'
-                : `${request.signatures.length} of ${multiSigDetails.threshold} signature${
-                    multiSigDetails.threshold === 1 ? '' : 's'
-                  } collected`}
-              {request.dateSubmitted !== '' &&
-                ` — submitted ${new Date(Number(request.dateSubmitted)).toLocaleDateString()}`}
-            </span>
-          </div>
-          <Button asChild variant='outline' size='sm'>
-            <Link href={`/request/${request.id}`} onClick={() => setSelectedMultiSigTransactionRequest(request.id)}>
-              Open
-            </Link>
-          </Button>
-        </div>
-      ))}
+      {requests.map((request, index) => {
+        const signaturesShown = Math.min(request.signatures.length, multiSigDetails.threshold)
+        return (
+          <motion.div
+            key={`Request-${request.id}`}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: Math.min(index, 8) * 0.04, ease: 'easeOut' }}
+            className='flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border p-3 transition-colors hover:border-primary/40 hover:bg-muted/30'
+          >
+            <div className='flex min-w-0 flex-1 flex-col gap-1.5'>
+              <span className='truncate text-sm font-semibold text-foreground'>{request.description}</span>
+              <span className='text-xs text-muted-foreground'>
+                {request.isExecuted
+                  ? 'Executed'
+                  : `${request.signatures.length} of ${multiSigDetails.threshold} signature${
+                      multiSigDetails.threshold === 1 ? '' : 's'
+                    } collected`}
+                {request.dateSubmitted !== '' &&
+                  ` — submitted ${new Date(Number(request.dateSubmitted)).toLocaleDateString()}`}
+              </span>
+              {!request.isExecuted && (
+                <div className='flex max-w-40 gap-1' aria-hidden>
+                  {Array.from({ length: multiSigDetails.threshold }, (_, i) => (
+                    <span
+                      key={i}
+                      className={`h-1 flex-1 rounded-full transition-colors duration-500 ${
+                        i < signaturesShown ? 'bg-primary' : 'bg-muted'
+                      }`}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+            <Button asChild variant='outline' size='sm'>
+              <Link href={`/request/${request.id}`} onClick={() => setSelectedMultiSigTransactionRequest(request.id)}>
+                Open
+              </Link>
+            </Button>
+          </motion.div>
+        )
+      })}
     </div>
   )
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,box-shadow,transform] duration-150 ease-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/src/components/ui/loading-dots.tsx
+++ b/src/components/ui/loading-dots.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface LoadingDotsProps extends React.HTMLAttributes<HTMLSpanElement> {
+  label?: string
+  size?: 'sm' | 'default'
+}
+
+// Three ember dots pulsing in sequence — the app's shared "reading the chain"
+// indicator. Pass a label to render the explanatory text alongside.
+const LoadingDots: React.FC<LoadingDotsProps> = ({ label, size = 'default', className, ...props }) => {
+  const dotClass = size === 'sm' ? 'h-1.5 w-1.5' : 'h-2 w-2'
+  return (
+    <span role='status' className={cn('inline-flex items-center gap-3', className)} {...props}>
+      <span className='inline-flex items-center gap-1'>
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            className={cn(dotClass, 'rounded-full bg-primary')}
+            style={{
+              animation: 'loading-dot 1.2s ease-in-out infinite',
+              animationDelay: `${i * 0.16}s`
+            }}
+          />
+        ))}
+      </span>
+      {label != null && <span className='text-sm text-muted-foreground'>{label}</span>}
+      {label == null && <span className='sr-only'>Loading</span>}
+    </span>
+  )
+}
+
+export { LoadingDots }

--- a/src/components/ui/reveal.tsx
+++ b/src/components/ui/reveal.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react'
+import { motion } from 'framer-motion'
+import { cn } from '@/lib/utils'
+
+interface WordRevealProps {
+  text: string
+  as?: React.ElementType
+  className?: string
+  delay?: number
+}
+
+// Headline entrance: each word rises out of a clipped line, staggered left to
+// right. Screen readers get the plain text; the animated copy is aria-hidden.
+const WordReveal: React.FC<WordRevealProps> = ({ text, as: Tag = 'h1', className, delay = 0 }) => {
+  const words = text.split(' ')
+  return (
+    <Tag className={className}>
+      <span className='sr-only'>{text}</span>
+      <span aria-hidden>
+        {words.map((word, i) => (
+          <span key={i} className='-mb-[0.14em] inline-block overflow-hidden pb-[0.14em] align-bottom'>
+            <motion.span
+              className='inline-block'
+              initial={{ y: '110%' }}
+              animate={{ y: 0 }}
+              transition={{ duration: 0.6, delay: delay + i * 0.08, ease: [0.22, 1, 0.36, 1] }}
+            >
+              {word}
+              {i < words.length - 1 ? ' ' : ''}
+            </motion.span>
+          </span>
+        ))}
+      </span>
+    </Tag>
+  )
+}
+
+interface TypedEyebrowProps {
+  text: string
+  className?: string
+  delay?: number
+}
+
+// Mono eyebrow that types on like terminal output, with a caret that blinks
+// while typing and then fades out.
+const TypedEyebrow: React.FC<TypedEyebrowProps> = ({ text, className, delay = 0.1 }) => {
+  const charDelay = 0.03
+  const typingTime = text.length * charDelay
+  return (
+    <p className={cn('font-mono text-xs tracking-[0.2em] text-primary', className)}>
+      <span className='sr-only'>{text}</span>
+      <span aria-hidden>
+        {text.split('').map((ch, i) => (
+          <motion.span
+            key={i}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.01, delay: delay + i * charDelay }}
+          >
+            {ch}
+          </motion.span>
+        ))}
+        <motion.span
+          className='ml-1 inline-block h-[1em] w-[0.55ch] translate-y-[0.18em] bg-primary'
+          initial={{ opacity: 1 }}
+          animate={{ opacity: [1, 0, 1, 0, 1, 0] }}
+          transition={{ delay, duration: typingTime + 1.1, ease: 'linear', times: [0, 0.2, 0.4, 0.6, 0.8, 1] }}
+        />
+      </span>
+    </p>
+  )
+}
+
+export { WordReveal, TypedEyebrow }

--- a/src/components/views/About.tsx
+++ b/src/components/views/About.tsx
@@ -62,10 +62,9 @@ const About: React.FC = () => {
             className="flex w-full flex-col gap-6 md:gap-8"
           >
             <motion.div variants={itemVariants} className="text-center">
-              <h1 className="mb-4 text-3xl font-extrabold leading-tight md:text-5xl">
-                <span className="bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent">
-                  About MyMultiSig
-                </span>
+              <p className="mb-3 font-mono text-xs tracking-[0.2em] text-primary">THE PROJECT</p>
+              <h1 className="mb-4 font-display text-3xl font-bold leading-tight tracking-tight text-foreground md:text-5xl">
+                About MyMultiSig
               </h1>
               <p className="mx-auto max-w-[700px] text-lg font-medium leading-relaxed text-foreground md:text-xl">
                 An open-source multisig smart contract and web app. Simple architecture, designed for

--- a/src/components/views/ConnectedWallet.tsx
+++ b/src/components/views/ConnectedWallet.tsx
@@ -61,14 +61,14 @@ const ConnectedWallet: React.FC = () => {
               className="h-10 w-10 rounded-full object-cover"
             />
           ) : (
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-primary to-blue-500 text-lg font-bold text-white">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/15 font-mono text-sm font-bold text-primary">
               {(ensName ?? address).slice(2, 4).toUpperCase()}
             </div>
           )}
           <div className="flex flex-1 flex-col items-start gap-1">
             <div className="flex items-center gap-2">
-              <span className="h-2 w-2 rounded-full bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.6)]" />
-              <span className="text-xs font-medium uppercase tracking-wider text-green-600 dark:text-green-400">
+              <span className="h-2 w-2 rounded-full bg-primary shadow-[0_0_8px] shadow-primary/60" />
+              <span className="font-mono text-xs uppercase tracking-wider text-primary">
                 Connected
               </span>
             </div>
@@ -96,7 +96,7 @@ const ConnectedWallet: React.FC = () => {
               title={hasCopied ? 'Copied!' : 'Copy address'}
             >
               {hasCopied ? (
-                <CheckIcon className="h-4 w-4 text-green-500" />
+                <CheckIcon className="h-4 w-4 animate-pop-in text-primary" />
               ) : (
                 <CopyIcon className="h-4 w-4" />
               )}

--- a/src/components/views/CreateMultiSig.tsx
+++ b/src/components/views/CreateMultiSig.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useAccount, useChainId, useChains } from 'wagmi'
 import { motion } from 'framer-motion'
 
+import { TypedEyebrow, WordReveal } from '@/components/ui/reveal'
 import BigCard from '../cards/BigCard'
 import ErrorCard from '../cards/ErrorCard'
 import ConnectWallet from './ConnectWallet'
@@ -50,10 +51,12 @@ const CreateMultiSig: React.FC = () => {
             className="flex w-full flex-col gap-6"
           >
             <motion.div variants={itemVariants} className="w-full">
-              <p className="mb-3 font-mono text-xs tracking-[0.2em] text-primary">NEW SHARED WALLET</p>
-              <h1 className="font-display text-3xl font-bold tracking-tight text-foreground md:text-4xl">
-                Create your multisig
-              </h1>
+              <TypedEyebrow text="NEW SHARED WALLET" className="mb-3" />
+              <WordReveal
+                text="Create your multisig"
+                delay={0.2}
+                className="font-display text-3xl font-bold tracking-tight text-foreground md:text-4xl"
+              />
               <p className="mt-2 text-sm text-muted-foreground">
                 Set up a new multi-signature wallet in just a few steps
               </p>

--- a/src/components/views/CreateMultiSig.tsx
+++ b/src/components/views/CreateMultiSig.tsx
@@ -49,13 +49,12 @@ const CreateMultiSig: React.FC = () => {
             animate="visible"
             className="flex w-full flex-col gap-6"
           >
-            <motion.div variants={itemVariants} className="w-full text-center">
-              <h1 className="mb-2 text-2xl font-extrabold md:text-4xl">
-                <span className="bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent">
-                  Create Your MultiSig
-                </span>
+            <motion.div variants={itemVariants} className="w-full">
+              <p className="mb-3 font-mono text-xs tracking-[0.2em] text-primary">NEW SHARED WALLET</p>
+              <h1 className="font-display text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+                Create your multisig
               </h1>
-              <p className="text-sm text-muted-foreground">
+              <p className="mt-2 text-sm text-muted-foreground">
                 Set up a new multi-signature wallet in just a few steps
               </p>
             </motion.div>

--- a/src/components/views/HeroQuorum.tsx
+++ b/src/components/views/HeroQuorum.tsx
@@ -12,24 +12,41 @@ const OWNERS = [
 
 const THRESHOLD = 2
 
+// The card loops the core mechanic forever: owners sign, quorum is reached,
+// the transaction executes, and the next proposal begins.
+type Phase = 'idle' | 'sig1' | 'sig2' | 'executed'
+
+const NEXT_PHASE: Record<Phase, { next: Phase; after: number }> = {
+  idle: { next: 'sig1', after: 1400 },
+  sig1: { next: 'sig2', after: 1100 },
+  sig2: { next: 'executed', after: 2600 },
+  executed: { next: 'idle', after: 3200 }
+}
+
 /**
- * Illustrative pending transaction that plays the core mechanic on load:
- * two of three owners sign, quorum is reached, execute unlocks.
+ * Illustrative pending transaction that plays the core mechanic on a loop:
+ * two of three owners sign, quorum is reached, execute fires, and the ledger
+ * advances to the next proposal. Reduced motion shows the quorum state static.
  */
 const HeroQuorum: React.FC = () => {
   const prefersReducedMotion = useReducedMotion()
-  const [signedCount, setSignedCount] = useState(prefersReducedMotion ? THRESHOLD : 0)
+  const [phase, setPhase] = useState<Phase>(prefersReducedMotion ? 'sig2' : 'idle')
+  const [proposalNumber, setProposalNumber] = useState(42)
 
   useEffect(() => {
     if (prefersReducedMotion) return
-    const timers = [
-      setTimeout(() => setSignedCount(1), 900),
-      setTimeout(() => setSignedCount(2), 1900)
-    ]
-    return () => timers.forEach(clearTimeout)
-  }, [prefersReducedMotion])
+    const { next, after } = NEXT_PHASE[phase]
+    const timer = setTimeout(() => {
+      if (phase === 'executed') setProposalNumber((n) => n + 1)
+      setPhase(next)
+    }, after)
+    return () => clearTimeout(timer)
+  }, [phase, prefersReducedMotion])
 
+  const signedCount = phase === 'idle' ? 0 : phase === 'sig1' ? 1 : 2
   const quorumReached = signedCount >= THRESHOLD
+  const executed = phase === 'executed'
+  const status = executed ? 'EXECUTED' : quorumReached ? 'QUORUM REACHED' : 'AWAITING SIGNATURES'
 
   return (
     <motion.div
@@ -41,22 +58,41 @@ const HeroQuorum: React.FC = () => {
       <div
         className={cn(
           'relative overflow-hidden rounded-xl border border-border bg-card transition-shadow duration-700',
-          quorumReached && 'shadow-[0_0_70px_-18px] shadow-primary/35'
+          quorumReached && !executed && 'shadow-[0_0_70px_-18px] shadow-primary/35',
+          executed && 'shadow-[0_0_80px_-14px] shadow-primary/50'
         )}
       >
         <div className="pointer-events-none absolute left-[10%] right-[10%] top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
 
         <div className="flex items-center justify-between border-b border-border px-5 py-3.5">
-          <span className="font-mono text-xs tracking-wider text-muted-foreground">PROPOSAL #0042</span>
+          <motion.span
+            key={proposalNumber}
+            initial={prefersReducedMotion ? false : { opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.35, ease: 'easeOut' }}
+            className="font-mono text-xs tracking-wider text-muted-foreground"
+          >
+            PROPOSAL #{String(proposalNumber).padStart(4, '0')}
+          </motion.span>
           <span
             className={cn(
               'rounded-full border px-2.5 py-0.5 font-mono text-[11px] tracking-wider transition-colors duration-500',
-              quorumReached
-                ? 'border-primary/40 bg-primary/15 text-primary'
-                : 'border-border bg-muted text-muted-foreground'
+              executed
+                ? 'border-primary bg-primary text-primary-foreground'
+                : quorumReached
+                  ? 'border-primary/40 bg-primary/15 text-primary'
+                  : 'border-border bg-muted text-muted-foreground'
             )}
           >
-            {quorumReached ? 'QUORUM REACHED' : 'AWAITING SIGNATURES'}
+            <motion.span
+              key={status}
+              initial={prefersReducedMotion ? false : { opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, ease: 'easeOut' }}
+              className="inline-block"
+            >
+              {status}
+            </motion.span>
           </span>
         </div>
 
@@ -120,9 +156,16 @@ const HeroQuorum: React.FC = () => {
               {signedCount} of {OWNERS.length} signed · {THRESHOLD} required
             </span>
           </div>
-          <Button size="sm" disabled={!quorumReached} className="shrink-0" tabIndex={-1}>
-            Execute transaction
-          </Button>
+          <motion.div
+            animate={executed && !prefersReducedMotion ? { scale: [1, 0.94, 1] } : { scale: 1 }}
+            transition={{ duration: 0.35, ease: 'easeOut' }}
+            className="shrink-0"
+          >
+            <Button size="sm" disabled={!quorumReached} className="gap-1.5" tabIndex={-1}>
+              {executed && <CheckIcon className="h-3.5 w-3.5" />}
+              {executed ? 'Executed' : 'Execute transaction'}
+            </Button>
+          </motion.div>
         </div>
       </div>
 

--- a/src/components/views/Privacy.tsx
+++ b/src/components/views/Privacy.tsx
@@ -64,10 +64,8 @@ const Privacy: React.FC = () => {
       <BigCard className="max-w-[900px]">
         <div className="flex w-full flex-col gap-8 py-4 md:py-8">
           <div>
-            <h1 className="font-display mb-2 text-3xl font-extrabold tracking-tight md:text-4xl">
-              <span className="bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent">
-                Privacy Policy
-              </span>
+            <h1 className="mb-2 font-display text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+              Privacy Policy
             </h1>
             <p className="font-mono text-xs text-muted-foreground">Last updated: {LAST_UPDATED}</p>
           </div>

--- a/src/components/views/Terms.tsx
+++ b/src/components/views/Terms.tsx
@@ -57,10 +57,8 @@ const Terms: React.FC = () => {
       <BigCard className="max-w-[900px]">
         <div className="flex w-full flex-col gap-8 py-4 md:py-8">
           <div>
-            <h1 className="font-display mb-2 text-3xl font-extrabold tracking-tight md:text-4xl">
-              <span className="bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent">
-                Terms &amp; Conditions
-              </span>
+            <h1 className="mb-2 font-display text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+              Terms &amp; Conditions
             </h1>
             <p className="font-mono text-xs text-muted-foreground">Last updated: {LAST_UPDATED}</p>
           </div>

--- a/src/components/views/UseYourMultiSig.tsx
+++ b/src/components/views/UseYourMultiSig.tsx
@@ -4,6 +4,7 @@ import { useAccount, useChainId, useChains } from 'wagmi'
 import { AddIcon, DownloadIcon, DeleteIcon } from '../icons/ChakraIcons'
 import { motion } from 'framer-motion'
 import { Button } from '@/components/ui/button'
+import { TypedEyebrow, WordReveal } from '@/components/ui/reveal'
 import BigCard from '../cards/BigCard'
 import ConnectWallet from './ConnectWallet'
 import MultiSigList from '../multiSigDetails/MultiSigList'
@@ -53,10 +54,12 @@ const UseYourMultiSig: React.FC = () => {
           className="flex w-full flex-col gap-8"
         >
           <motion.div variants={itemVariants}>
-            <p className="mb-3 font-mono text-xs tracking-[0.2em] text-primary">YOUR MULTISIGS</p>
-            <h1 className="font-display text-3xl font-bold tracking-tight text-foreground md:text-4xl">
-              Open a multisig
-            </h1>
+            <TypedEyebrow text="YOUR MULTISIGS" className="mb-3" />
+            <WordReveal
+              text="Open a multisig"
+              delay={0.2}
+              className="font-display text-3xl font-bold tracking-tight text-foreground md:text-4xl"
+            />
             {chain && (
               <div className="mt-3 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
                 <span className="flex items-center gap-1.5">

--- a/src/components/views/Welcome.tsx
+++ b/src/components/views/Welcome.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { useAccount } from 'wagmi'
 import { Button } from '@/components/ui/button'
+import { TypedEyebrow, WordReveal } from '@/components/ui/reveal'
 import ConnectWallet from './ConnectWallet'
 import ConnectedWallet from './ConnectedWallet'
 import HeroQuorum from './HeroQuorum'
@@ -112,18 +113,28 @@ const Welcome: React.FC = () => {
 
       {/* Hero */}
       <section className="grid items-center gap-10 pt-2 md:pt-8 lg:grid-cols-[1.1fr_1fr] lg:gap-14">
-        <motion.div variants={sectionVariants} initial="hidden" animate="visible">
-          <p className="mb-4 font-mono text-xs tracking-[0.2em] text-primary">
-            SHARED WALLETS, ENFORCED ONCHAIN
-          </p>
-          <h1 className="font-display text-4xl font-bold leading-[1.05] tracking-tight text-foreground md:text-5xl lg:text-6xl">
-            No single key can move the funds.
-          </h1>
-          <p className="mt-5 max-w-lg text-lg leading-relaxed text-muted-foreground">
+        <div>
+          <TypedEyebrow text="SHARED WALLETS, ENFORCED ONCHAIN" className="mb-4" />
+          <WordReveal
+            text="No single key can move the funds."
+            delay={0.25}
+            className="font-display text-4xl font-bold leading-[1.05] tracking-tight text-foreground md:text-5xl lg:text-6xl"
+          />
+          <motion.p
+            initial={{ opacity: 0, y: 14 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.7, ease: 'easeOut' }}
+            className="mt-5 max-w-lg text-lg leading-relaxed text-muted-foreground"
+          >
             Create a shared wallet, choose its owners, and set how many must approve. Every transaction
             waits for that quorum—then anyone on the team can execute it.
-          </p>
-          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          </motion.p>
+          <motion.div
+            initial={{ opacity: 0, y: 14 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.85, ease: 'easeOut' }}
+            className="mt-8 flex flex-col gap-3 sm:flex-row"
+          >
             <Button size="lg" className="gap-2 px-7" asChild>
               <Link href="/createMultiSig">
                 <AddIcon className="h-4 w-4" />
@@ -136,8 +147,13 @@ const Welcome: React.FC = () => {
                 Open an existing multisig
               </Link>
             </Button>
-          </div>
-          <div className="mt-6 flex items-center gap-5 font-mono text-xs text-muted-foreground">
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5, delay: 1.05 }}
+            className="mt-6 flex items-center gap-5 font-mono text-xs text-muted-foreground"
+          >
             <Link href="/integration" className="transition-colors hover:text-foreground">
               Integration
             </Link>
@@ -151,8 +167,8 @@ const Welcome: React.FC = () => {
               Review the code
               <ExternalLinkIcon className="h-3 w-3" />
             </a>
-          </div>
-        </motion.div>
+          </motion.div>
+        </div>
 
         <HeroQuorum />
       </section>

--- a/src/components/views/Welcome.tsx
+++ b/src/components/views/Welcome.tsx
@@ -16,7 +16,17 @@ const sectionVariants = {
   visible: {
     opacity: 1,
     y: 0,
-    transition: { duration: 0.5, ease: 'easeOut' as const }
+    transition: { duration: 0.5, ease: 'easeOut' as const, staggerChildren: 0.08 }
+  }
+}
+
+// For items inside a section: the parent drives timing via staggerChildren.
+const childVariants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.4, ease: 'easeOut' as const }
   }
 }
 
@@ -159,11 +169,11 @@ const Welcome: React.FC = () => {
         </h2>
         <div className="mt-6 grid grid-cols-1 gap-8 border-t border-border pt-8 md:grid-cols-3 md:gap-10">
           {howItWorksSteps.map((item) => (
-            <div key={item.step}>
+            <motion.div key={item.step} variants={childVariants}>
               <span className="font-mono text-sm text-primary">{item.step}</span>
               <h3 className="mt-2 text-lg font-semibold text-foreground">{item.title}</h3>
               <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{item.description}</p>
-            </div>
+            </motion.div>
           ))}
         </div>
       </motion.section>
@@ -177,11 +187,15 @@ const Welcome: React.FC = () => {
       >
         <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
           {principles.map((item) => (
-            <div key={item.title} className="rounded-xl border border-border bg-card p-6">
+            <motion.div
+              key={item.title}
+              variants={childVariants}
+              className="rounded-xl border border-border bg-card p-6 transition-colors duration-200 hover:border-primary/40"
+            >
               <span className="font-mono text-xs text-primary">{item.keyword}</span>
               <h3 className="mt-2 text-lg font-semibold text-foreground">{item.title}</h3>
               <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{item.description}</p>
-            </div>
+            </motion.div>
           ))}
         </div>
         <div className="mt-6 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
@@ -205,10 +219,10 @@ const Welcome: React.FC = () => {
         <h2 className="font-display text-2xl font-bold tracking-tight text-foreground md:text-3xl">FAQ</h2>
         <div className="mt-6 grid grid-cols-1 gap-x-12 gap-y-8 border-t border-border pt-8 md:grid-cols-2">
           {faqItems.map((item) => (
-            <div key={item.q}>
+            <motion.div key={item.q} variants={childVariants}>
               <h3 className="text-sm font-semibold text-foreground">{item.q}</h3>
               <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">{item.a}</p>
-            </div>
+            </motion.div>
           ))}
         </div>
       </motion.section>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,10 +1,34 @@
 import React from 'react'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import { Button } from '@/components/ui/button'
 
 const Error: React.FC = () => {
   return (
-    <h1 className="text-center text-2xl font-bold text-foreground">
-      404 - Something went wrong
-    </h1>
+    <div className='flex min-h-[50vh] items-center justify-center'>
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, ease: 'easeOut' }}
+        className='flex flex-col items-center text-center'
+      >
+        <p className='font-mono text-xs tracking-[0.2em] text-primary'>ERROR 404</p>
+        <h1 className='mt-3 font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl'>
+          This page does not exist
+        </h1>
+        <p className='mt-4 max-w-md text-sm leading-relaxed text-muted-foreground'>
+          The address may be mistyped, or the page may have moved. Your multisigs are unaffected.
+        </p>
+        <div className='mt-8 flex flex-wrap justify-center gap-3'>
+          <Button asChild>
+            <Link href='/'>Back to home</Link>
+          </Button>
+          <Button variant='outline' asChild>
+            <Link href='/useYourMultiSig'>Open a multisig</Link>
+          </Button>
+        </div>
+      </motion.div>
+    </div>
   )
 }
 

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,10 +1,32 @@
 import React from 'react'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import { Button } from '@/components/ui/button'
 
 const Error: React.FC = () => {
   return (
-    <h1 className="text-center text-2xl font-bold text-foreground">
-      500 - Something went wrong
-    </h1>
+    <div className='flex min-h-[50vh] items-center justify-center'>
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, ease: 'easeOut' }}
+        className='flex flex-col items-center text-center'
+      >
+        <p className='font-mono text-xs tracking-[0.2em] text-primary'>ERROR 500</p>
+        <h1 className='mt-3 font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl'>
+          Something went wrong
+        </h1>
+        <p className='mt-4 max-w-md text-sm leading-relaxed text-muted-foreground'>
+          The app hit an unexpected error. Your funds and multisigs live on-chain and are unaffected — try reloading the
+          page.
+        </p>
+        <div className='mt-8 flex flex-wrap justify-center gap-3'>
+          <Button asChild>
+            <Link href='/'>Back to home</Link>
+          </Button>
+        </div>
+      </motion.div>
+    </div>
   )
 }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -18,6 +18,11 @@ const monoFont = JetBrains_Mono({ subsets: ['latin'], display: 'swap' })
 
 const App: React.FC<AppProps> = ({ Component, pageProps = { title: 'MyMultiSig' } }) => {
   const router = useRouter()
+  // Multisig tab pages share one key: switching tabs swaps content in place
+  // (letting the nav pill slide) instead of replaying the page transition.
+  const transitionKey = router.route.startsWith('/multisig/[multisigAddress]')
+    ? '/multisig/[multisigAddress]'
+    : router.route
   return (
     <>
       {/* Font families exposed on :root so portaled content (dialogs, toasts) inherits them too */}
@@ -36,7 +41,7 @@ const App: React.FC<AppProps> = ({ Component, pageProps = { title: 'MyMultiSig' 
             <Layout>
               <AnimatePresence mode="wait" initial={false}>
                 <motion.div
-                  key={router.route}
+                  key={transitionKey}
                   initial={{ opacity: 0, y: 8 }}
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -4, transition: { duration: 0.15, ease: 'easeIn' } }}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -39,7 +39,8 @@ const App: React.FC<AppProps> = ({ Component, pageProps = { title: 'MyMultiSig' 
         <MotionConfig reducedMotion="user">
           <Web3Provider>
             <Layout>
-              <AnimatePresence mode="wait" initial={false}>
+              {/* No initial={false}: it would suppress every child entrance animation on first load */}
+              <AnimatePresence mode="wait">
                 <motion.div
                   key={transitionKey}
                   initial={{ opacity: 0, y: 8 }}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import Script from 'next/script'
 import { AppProps } from 'next/app'
+import { useRouter } from 'next/router'
 import { ThemeProvider } from 'next-themes'
 import { Toaster } from 'sonner'
+import { AnimatePresence, MotionConfig, motion } from 'framer-motion'
 import { Bricolage_Grotesque, Instrument_Sans, JetBrains_Mono } from 'next/font/google'
 
 import '../styles/globals.css'
@@ -15,6 +17,7 @@ const bodyFont = Instrument_Sans({ subsets: ['latin'], display: 'swap' })
 const monoFont = JetBrains_Mono({ subsets: ['latin'], display: 'swap' })
 
 const App: React.FC<AppProps> = ({ Component, pageProps = { title: 'MyMultiSig' } }) => {
+  const router = useRouter()
   return (
     <>
       {/* Font families exposed on :root so portaled content (dialogs, toasts) inherits them too */}
@@ -27,11 +30,24 @@ const App: React.FC<AppProps> = ({ Component, pageProps = { title: 'MyMultiSig' 
       `}</style>
       <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
         <Header title={pageProps.title} />
-        <Web3Provider>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </Web3Provider>
+        {/* reducedMotion="user" makes every framer-motion animation respect prefers-reduced-motion */}
+        <MotionConfig reducedMotion="user">
+          <Web3Provider>
+            <Layout>
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.div
+                  key={router.route}
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -4, transition: { duration: 0.15, ease: 'easeIn' } }}
+                  transition={{ duration: 0.25, ease: [0.25, 1, 0.5, 1] }}
+                >
+                  <Component {...pageProps} />
+                </motion.div>
+              </AnimatePresence>
+            </Layout>
+          </Web3Provider>
+        </MotionConfig>
         <Toaster position="top-right" richColors closeButton />
       </ThemeProvider>
       <Script

--- a/src/pages/multisig/[multisigAddress]/requests.tsx
+++ b/src/pages/multisig/[multisigAddress]/requests.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useRouter } from 'next/router'
 import { useAccount } from 'wagmi'
 
+import { LoadingDots } from '@/components/ui/loading-dots'
 import MultiSigPageLayout from '../../../components/multiSigDetails/MultiSigPageLayout'
 import MultiSigRequestList from '../../../components/multiSigDetails/MultiSigRequestList'
 import useMultiSigDetails from '../../../hooks/useMultiSigDetails'
@@ -21,9 +22,8 @@ const Page: React.FC = () => {
   return (
     <MultiSigPageLayout multiSigAddress={multisigAddress as `0x${string}`}>
       {multiSigDetails == null ? (
-        <div className='flex w-full items-center justify-center gap-3 rounded-xl border border-border bg-muted/30 p-6'>
-          <span className='h-3 w-3 animate-pulse rounded-full bg-primary' />
-          <span className='text-sm text-muted-foreground'>Reading the multisig contract...</span>
+        <div className='flex w-full items-center justify-center rounded-xl border border-border bg-muted/30 p-6'>
+          <LoadingDots label='Reading the multisig contract...' />
         </div>
       ) : (
         <MultiSigRequestList multiSigAddress={multisigAddress as `0x${string}`} multiSigDetails={multiSigDetails} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -106,6 +106,44 @@
     --sidebar-ring: oklch(0.6 0.2 41.116 / 60%);
   }
 
+/*
+ * Motion vocabulary: exponential ease-outs for entrances and state changes.
+ * Feedback stays under 150ms, state changes 200-300ms, entrances up to 500ms.
+ */
+:root {
+  --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes loading-dot {
+  0%,
+  80%,
+  100% {
+    opacity: 0.25;
+    transform: scale(0.85);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes pop-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-pop-in {
+  animation: pop-in 200ms var(--ease-out-quart) both;
+}
+
 * {
   border-color: var(--border);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -129,6 +129,18 @@
   }
 }
 
+/* Slow breathing of the ambient ember glow behind the page. */
+@keyframes ember-breathe {
+  from {
+    opacity: 0.7;
+    transform: scaleY(1);
+  }
+  to {
+    opacity: 1;
+    transform: scaleY(1.1);
+  }
+}
+
 @keyframes pop-in {
   0% {
     opacity: 0;


### PR DESCRIPTION
## Summary

Extends the ember-ledger design direction with a coherent motion layer and fixes several spots that had drifted off theme.

### Motion foundation
- Easing tokens (`--ease-out-quart/quint/expo`) and shared keyframes in `globals.css`
- `MotionConfig reducedMotion="user"` so **every** framer-motion animation now respects `prefers-reduced-motion`
- Route changes crossfade (250ms in / 150ms out); multisig tab pages share one transition key so the wallet shell stays steady while tab content swaps in place

### Micro-interactions
- Buttons get tactile press feedback (`active:scale-[0.97]`, 150ms)
- Copy-address and success check icons pop in, in ember orange
- Linked stat tiles lift with an ember shadow on hover
- Multisig tab nav's active pill slides between tabs (framer `layoutId`)

### Loading & lists
- New shared `LoadingDots` (three staggered ember dots) replaces the nine lone pulsing dots
- Request rows enter with a short stagger and show quorum progress as ember segments (echoing the HeroQuorum meter)
- Homepage sections stagger their children on scroll reveal

### Theme consistency
- Gradient headings (Create, About, Terms, Privacy) replaced with the mono-eyebrow + Bricolage display pattern
- Off-theme greens and a blue gradient avatar swept onto the single ember accent
- 404/500 pages redesigned to match the app (eyebrow, display heading, recovery actions)

## Verification

- `yarn build` passes (also the lint gate)
- Drove the production build headlessly with Playwright against an anvil Sepolia fork with an injected wallet: staggered homepage reveals, route crossfade, sliding tab pill (caught mid-flight), LoadingDots on contract reads, ember copy-check pop, and the new 404 all render correctly
- `yarn prettier` / `npx jest` fail identically on `main` (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)