### PR TITLE
feat(assets): wallet assets tab with token and NFT holdings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ DATABASE_URL=
 ETHERSCAN_API_KEY=
 # Token/NFT balances on the Assets tab (falls back to NEXT_PUBLIC_ALCHEMY_API_KEY)
 ALCHEMY_API_KEY=
+# Comma-separated wallet addresses allowed to view the public address book (/admin)
+ADMIN_ADDRESSES=
 PRIVATE_KEY=
 RPC_ETHEREUM=
 SLACK_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ NEXT_PUBLIC_APP_GTAG=
 # Server-only variables
 DATABASE_URL=
 ETHERSCAN_API_KEY=
+# Token/NFT balances on the Assets tab (falls back to NEXT_PUBLIC_ALCHEMY_API_KEY)
+ALCHEMY_API_KEY=
 PRIVATE_KEY=
 RPC_ETHEREUM=
 SLACK_TOKEN=

--- a/.env.sample
+++ b/.env.sample
@@ -21,6 +21,9 @@ ETHERSCAN_API_KEY=""
 # alchemy api key (token/NFT balances on the Assets tab)
 ALCHEMY_API_KEY=""
 
+# comma-separated admin wallet addresses (public address book review on /admin)
+ADMIN_ADDRESSES=""
+
 # Next-Auth Github
 GITHUB_ID=""
 GITHUB_SECRET=""

--- a/.env.sample
+++ b/.env.sample
@@ -18,6 +18,9 @@ SLACK_CONVERSATION_ID=""
 # etherscan api key
 ETHERSCAN_API_KEY=""
 
+# alchemy api key (token/NFT balances on the Assets tab)
+ALCHEMY_API_KEY=""
+
 # Next-Auth Github
 GITHUB_ID=""
 GITHUB_SECRET=""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ All contract writes follow the same flow:
 - `DATABASE_URL` — Neon PostgreSQL connection string (required for API routes)
 - `SESSION_SECRET` — HMAC secret for SIWE session cookies (falls back to legacy `PRIVATE_KEY` if set)
 - `ETHERSCAN_API_KEY` — ABI fetching via `/api/getABI`
+- `ALCHEMY_API_KEY` — token/NFT balances via `/api/get-assets` (falls back to `NEXT_PUBLIC_ALCHEMY_API_KEY`)
 - `RESEND_API_KEY` / `RESEND_CONTACT_TO` — contact form via `/api/contact` (`RESEND_FROM` optional, defaults to Resend's onboarding sender)
 
 ## Known Issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ All contract writes follow the same flow:
 - `SESSION_SECRET` — HMAC secret for SIWE session cookies (falls back to legacy `PRIVATE_KEY` if set)
 - `ETHERSCAN_API_KEY` — ABI fetching via `/api/getABI`
 - `ALCHEMY_API_KEY` — token/NFT balances via `/api/get-assets` (falls back to `NEXT_PUBLIC_ALCHEMY_API_KEY`)
+- `ADMIN_ADDRESSES` — comma-separated wallets allowed to view publicly shared address book entries on `/admin`
 - `RESEND_API_KEY` / `RESEND_CONTACT_TO` — contact form via `/api/contact` (`RESEND_FROM` optional, defaults to Resend's onboarding sender)
 
 ## Known Issues

--- a/src/components/icons/ChakraIcons.tsx
+++ b/src/components/icons/ChakraIcons.tsx
@@ -24,6 +24,8 @@ import {
   Info as InfoIconLucide,
   ArrowLeft as ArrowLeftIconLucide,
   Coins as CoinsIconLucide,
+  Image as ImageIconLucide,
+  RefreshCw as RefreshIconLucide,
   Import as ImportIconLucide,
   Wallet as WalletIconLucide,
   BookUser as BookUserIconLucide
@@ -68,6 +70,8 @@ export const InfoIcon = withIcon(InfoIconLucide, 'InfoIcon')
 export const InfoOutlineIcon = withIcon(InfoIconLucide, 'InfoOutlineIcon')
 export const ArrowBackIcon = withIcon(ArrowLeftIconLucide, 'ArrowBackIcon')
 export const CoinsIcon = withIcon(CoinsIconLucide, 'CoinsIcon')
+export const ImageIcon = withIcon(ImageIconLucide, 'ImageIcon')
+export const RefreshIcon = withIcon(RefreshIconLucide, 'RefreshIcon')
 export const ImportIcon = withIcon(ImportIconLucide, 'ImportIcon')
 export const WalletIcon = withIcon(WalletIconLucide, 'WalletIcon')
 export const AddressBookIcon = withIcon(BookUserIconLucide, 'AddressBookIcon')

--- a/src/components/modals/AddTokenModal.stories.tsx
+++ b/src/components/modals/AddTokenModal.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import AddTokenModal from './AddTokenModal'
+import Web3Provider from '../web3/Web3Provider'
+
+const meta: Meta<typeof AddTokenModal> = {
+  title: 'Modals/AddTokenModal',
+  component: AddTokenModal
+}
+
+export default meta
+
+export const Default: StoryFn<typeof AddTokenModal> = () => (
+  <Web3Provider>
+    <AddTokenModal
+      multiSigAddress='0x792e44D0E6De4B1b774f39952657943Ad2A50930'
+      open={true}
+      onOpenChange={() => {}}
+    />
+  </Web3Provider>
+)

--- a/src/components/modals/AddTokenModal.tsx
+++ b/src/components/modals/AddTokenModal.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react'
 import { erc20Abi, formatUnits, isAddress } from 'viem'
-import { useChainId, useChains, useReadContracts } from 'wagmi'
+import { useAccount, useChainId, useChains, useReadContracts } from 'wagmi'
 import { toast } from 'sonner'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
 import { CoinsIcon } from '../icons/ChakraIcons'
 import TextInput from '../inputs/TextInput'
 import useCustomTokens from '../../states/customTokens'
+import useAddressBook from '../../states/addressBook'
+import { persistAddressBookUpsert } from '../../utils/addressBookSync'
 
 interface AddTokenModalProps {
   multiSigAddress: `0x${string}`
@@ -21,8 +24,12 @@ const AddTokenModal: React.FC<AddTokenModalProps> = ({ multiSigAddress, open, on
   const chainId = useChainId()
   const chains = useChains()
   const chain = chains.find((c) => c.id === chainId)
+  const { address: connectedAddress } = useAccount()
   const [tokenAddress, setTokenAddress] = useState('')
+  const [saveToBook, setSaveToBook] = useState(false)
+  const [shareInBook, setShareInBook] = useState(false)
   const { tokens, addToken } = useCustomTokens()
+  const { entries, addEntry } = useAddressBook()
 
   const tokenAddressValid = isAddress(tokenAddress)
   // name is optional in ERC-20, so reads allow individual failure; only
@@ -53,9 +60,16 @@ const AddTokenModal: React.FC<AddTokenModalProps> = ({ multiSigAddress, open, on
   const alreadyAdded =
     tokenAddressValid &&
     tokens.some((t) => t.chainId === chain?.id && t.address.toLowerCase() === tokenAddress.toLowerCase())
+  const alreadyInBook =
+    tokenAddressValid &&
+    entries.some((e) => e.chainId === chain?.id && e.address.toLowerCase() === tokenAddress.toLowerCase())
 
   const close = (nextOpen: boolean) => {
-    if (!nextOpen) setTokenAddress('')
+    if (!nextOpen) {
+      setTokenAddress('')
+      setSaveToBook(false)
+      setShareInBook(false)
+    }
     onOpenChange(nextOpen)
   }
 
@@ -68,7 +82,22 @@ const AddTokenModal: React.FC<AddTokenModalProps> = ({ multiSigAddress, open, on
       name: name ?? symbol,
       decimals
     })
-    toast.success(`${symbol} added to this wallet's token list.`)
+    // An existing book entry (and its label/visibility) wins over the token
+    // metadata; only genuinely new addresses get written to the book.
+    if (saveToBook && !alreadyInBook) {
+      const entry = {
+        chainId: chain.id,
+        address: tokenAddress as `0x${string}`,
+        label: symbol,
+        kind: 'contract' as const,
+        isPublic: shareInBook
+      }
+      addEntry(entry)
+      persistAddressBookUpsert(entry, connectedAddress)
+      toast.success(`${symbol} added to the token list and your address book.`)
+    } else {
+      toast.success(`${symbol} added to this wallet's token list.`)
+    }
     close(false)
   }
 
@@ -121,6 +150,34 @@ const AddTokenModal: React.FC<AddTokenModalProps> = ({ multiSigAddress, open, on
                 <span className='font-mono text-sm text-foreground'>
                   {Number(formatUnits(balance, decimals)).toLocaleString(undefined, { maximumFractionDigits: 5 })}
                 </span>
+              )}
+            </div>
+          )}
+
+          {isToken && !alreadyAdded && (
+            <div className='flex flex-col gap-3 rounded-lg border border-border bg-muted/30 p-3'>
+              <label className='flex items-center justify-between gap-3'>
+                <span className='flex flex-col gap-0.5'>
+                  <span className='text-sm font-medium text-foreground'>Also save to my address book</span>
+                  <span className='text-xs text-muted-foreground'>
+                    {alreadyInBook
+                      ? 'This address is already in your book; its existing entry stays as is.'
+                      : `Label ${symbol} wherever its address appears — in the request builder, activity, and transfers.`}
+                  </span>
+                </span>
+                <Switch checked={saveToBook && !alreadyInBook} onCheckedChange={setSaveToBook} disabled={alreadyInBook} />
+              </label>
+              {saveToBook && !alreadyInBook && (
+                <label className='flex items-center justify-between gap-3 border-t border-border pt-3'>
+                  <span className='flex flex-col gap-0.5'>
+                    <span className='text-sm font-medium text-foreground'>Share publicly</span>
+                    <span className='text-xs text-muted-foreground'>
+                      Public entries can be seen by the MyMultiSig team, helping widely used contracts get official
+                      support. Private entries stay visible to you alone.
+                    </span>
+                  </span>
+                  <Switch checked={shareInBook} onCheckedChange={setShareInBook} />
+                </label>
               )}
             </div>
           )}

--- a/src/components/modals/AddTokenModal.tsx
+++ b/src/components/modals/AddTokenModal.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react'
+import { erc20Abi, formatUnits, isAddress } from 'viem'
+import { useChainId, useChains, useReadContracts } from 'wagmi'
+import { toast } from 'sonner'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { CoinsIcon } from '../icons/ChakraIcons'
+import TextInput from '../inputs/TextInput'
+import useCustomTokens from '../../states/customTokens'
+
+interface AddTokenModalProps {
+  multiSigAddress: `0x${string}`
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+// Track an ERC-20 by contract address, MetaMask-import style. The token is
+// stored locally per chain and its balance read straight from the chain, so
+// it also covers networks (or tokens) the indexer misses.
+const AddTokenModal: React.FC<AddTokenModalProps> = ({ multiSigAddress, open, onOpenChange }) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const [tokenAddress, setTokenAddress] = useState('')
+  const { tokens, addToken } = useCustomTokens()
+
+  const tokenAddressValid = isAddress(tokenAddress)
+  // name is optional in ERC-20, so reads allow individual failure; only
+  // symbol + decimals decide whether this address really is a token.
+  const { data: tokenData, isLoading } = useReadContracts({
+    contracts: [
+      { address: tokenAddress as `0x${string}`, abi: erc20Abi, functionName: 'symbol', chainId: chain?.id },
+      { address: tokenAddress as `0x${string}`, abi: erc20Abi, functionName: 'decimals', chainId: chain?.id },
+      { address: tokenAddress as `0x${string}`, abi: erc20Abi, functionName: 'name', chainId: chain?.id },
+      {
+        address: tokenAddress as `0x${string}`,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [multiSigAddress],
+        chainId: chain?.id
+      }
+    ],
+    query: { enabled: tokenAddressValid }
+  })
+
+  const symbol = tokenData?.[0]?.status === 'success' ? String(tokenData[0].result) : null
+  const decimals = tokenData?.[1]?.status === 'success' ? Number(tokenData[1].result) : null
+  const name = tokenData?.[2]?.status === 'success' ? String(tokenData[2].result) : null
+  const balance = tokenData?.[3]?.status === 'success' ? (tokenData[3].result as bigint) : null
+  const isToken = symbol != null && decimals != null
+  const notAToken = tokenAddressValid && tokenData != null && !isToken
+
+  const alreadyAdded =
+    tokenAddressValid &&
+    tokens.some((t) => t.chainId === chain?.id && t.address.toLowerCase() === tokenAddress.toLowerCase())
+
+  const close = (nextOpen: boolean) => {
+    if (!nextOpen) setTokenAddress('')
+    onOpenChange(nextOpen)
+  }
+
+  const add = () => {
+    if (!isToken || chain == null) return
+    addToken({
+      chainId: chain.id,
+      address: tokenAddress,
+      symbol,
+      name: name ?? symbol,
+      decimals
+    })
+    toast.success(`${symbol} added to this wallet's token list.`)
+    close(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent showClose={true} className='max-w-[480px] border-border bg-card/98 backdrop-blur-xl'>
+        <DialogHeader className='pb-2 pt-6'>
+          <DialogTitle className='font-display text-xl font-bold tracking-tight text-foreground'>
+            Add a token
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className='flex flex-col gap-4 pb-6'>
+          <p className='text-sm leading-relaxed text-muted-foreground'>
+            Track any ERC-20 token on {chain?.name ?? 'this network'} by its contract address. Its balance is read
+            straight from the chain, so this also works for tokens the indexer misses.
+          </p>
+
+          <div className='flex flex-col gap-1'>
+            <TextInput
+              placeholder='Token contract address (0x...)'
+              value={tokenAddress}
+              onChange={(e) => setTokenAddress(e.target.value.trim())}
+              isInvalid={tokenAddress !== '' && !tokenAddressValid}
+              className='md:w-full'
+            />
+            {tokenAddress !== '' && !tokenAddressValid && (
+              <span className='text-xs text-destructive'>This is not a valid address.</span>
+            )}
+            {tokenAddressValid && isLoading && (
+              <span className='text-xs text-muted-foreground'>Reading the token...</span>
+            )}
+            {notAToken && (
+              <span className='text-xs text-destructive'>
+                This address does not respond like an ERC-20 on {chain?.name ?? 'this network'}.
+              </span>
+            )}
+          </div>
+
+          {isToken && (
+            <div className='flex items-center gap-3 rounded-lg border border-border bg-muted/30 p-3'>
+              <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted'>
+                <CoinsIcon className='h-4 w-4 text-muted-foreground' />
+              </span>
+              <div className='flex min-w-0 flex-1 flex-col'>
+                <span className='text-sm font-medium text-foreground'>{symbol}</span>
+                <span className='truncate text-xs text-muted-foreground'>{name ?? tokenAddress}</span>
+              </div>
+              {balance != null && (
+                <span className='font-mono text-sm text-foreground'>
+                  {Number(formatUnits(balance, decimals)).toLocaleString(undefined, { maximumFractionDigits: 5 })}
+                </span>
+              )}
+            </div>
+          )}
+
+          {alreadyAdded && (
+            <p className='rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground'>
+              This token is already in the list.
+            </p>
+          )}
+
+          <Button size='lg' disabled={!isToken || alreadyAdded} onClick={add} className='w-full'>
+            {isToken ? `Add ${symbol}` : 'Add token'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default AddTokenModal

--- a/src/components/multiSigDetails/MultiSigAssets.stories.tsx
+++ b/src/components/multiSigDetails/MultiSigAssets.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import MultiSigAssets from './MultiSigAssets'
+
+const meta: Meta<typeof MultiSigAssets> = {
+  title: 'MultiSigDetails/MultiSigAssets',
+  component: MultiSigAssets
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof MultiSigAssets> = (args: React.ComponentProps<typeof MultiSigAssets>) => (
+  <MultiSigAssets {...args} />
+)
+Basic.args = {
+  multiSigAddress: '0x2222222222222222222222222222222222222222'
+}

--- a/src/components/multiSigDetails/MultiSigAssets.tsx
+++ b/src/components/multiSigDetails/MultiSigAssets.tsx
@@ -1,0 +1,214 @@
+import React from 'react'
+import { useBalance, useChainId, useChains } from 'wagmi'
+import { formatEther, formatUnits } from 'viem'
+import { Button } from '@/components/ui/button'
+import { LoadingDots } from '@/components/ui/loading-dots'
+import { CoinsIcon, ExternalLinkIcon, ImageIcon, RefreshIcon } from '../icons/ChakraIcons'
+
+import useWalletAssets from '../../hooks/useWalletAssets'
+import { NftHolding, TokenHolding } from '../../models/Assets'
+
+interface MultiSigAssetsProps {
+  multiSigAddress: `0x${string}`
+}
+
+const formatAmount = (value: bigint, decimals: number) =>
+  Number(formatUnits(value, decimals)).toLocaleString(undefined, { maximumFractionDigits: 5 })
+
+const truncate = (value: string, head = 8, tail = 6) =>
+  value.length > head + tail + 2 ? `${value.slice(0, head)}...${value.slice(-tail)}` : value
+
+// Remote logos and NFT images regularly 404 or point at dead IPFS gateways, so
+// every image swaps to an icon placeholder on error instead of a broken glyph.
+const AssetImage: React.FC<{
+  src: string | null
+  alt: string
+  fallback: React.ReactNode
+  className: string
+}> = ({ src, alt, fallback, className }) => {
+  const [errored, setErrored] = React.useState(false)
+  React.useEffect(() => setErrored(false), [src])
+  if (src == null || errored) return <>{fallback}</>
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img src={src} alt={alt} className={className} onError={() => setErrored(true)} loading='lazy' />
+}
+
+const TokenRow: React.FC<{
+  logo: string | null
+  symbol: string
+  name: string
+  amount: string
+  badge?: string
+  explorerHref?: string
+}> = ({ logo, symbol, name, amount, badge, explorerHref }) => (
+  <div className='flex items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-muted/40'>
+    <AssetImage
+      src={logo}
+      alt={symbol}
+      className='h-8 w-8 shrink-0 rounded-full object-cover'
+      fallback={
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted'>
+          <CoinsIcon className='h-4 w-4 text-muted-foreground' />
+        </span>
+      }
+    />
+    <div className='flex min-w-0 flex-1 flex-col'>
+      <span className='flex items-center gap-2 text-sm font-medium text-foreground'>
+        {symbol}
+        {badge != null && (
+          <span className='rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground'>{badge}</span>
+        )}
+      </span>
+      <span className='truncate text-xs text-muted-foreground'>{name}</span>
+    </div>
+    <span className='font-mono text-sm text-foreground'>{amount}</span>
+    {explorerHref != null && (
+      <a
+        href={explorerHref}
+        target='_blank'
+        rel='noopener noreferrer'
+        aria-label={`View ${symbol} on the block explorer`}
+        className='text-muted-foreground transition-colors hover:text-foreground'
+      >
+        <ExternalLinkIcon className='h-3.5 w-3.5' />
+      </a>
+    )}
+  </div>
+)
+
+const NftCard: React.FC<{ nft: NftHolding; explorerUrl?: string }> = ({ nft, explorerUrl }) => {
+  const title = nft.name ?? (nft.collectionName != null ? `${nft.collectionName} #${truncate(nft.tokenId, 6, 4)}` : `#${truncate(nft.tokenId, 6, 4)}`)
+  const card = (
+    <>
+      <div className='flex aspect-square w-full items-center justify-center overflow-hidden rounded-lg bg-muted'>
+        <AssetImage
+          src={nft.imageUrl}
+          alt={title}
+          className='h-full w-full object-cover'
+          fallback={<ImageIcon className='h-8 w-8 text-muted-foreground' />}
+        />
+      </div>
+      <span className='truncate text-sm font-medium text-foreground'>{title}</span>
+      <span className='truncate text-xs text-muted-foreground'>
+        {nft.collectionName ?? truncate(nft.contractAddress)} · #{truncate(nft.tokenId, 6, 4)}
+        {nft.tokenType === 'ERC1155' && nft.balance !== '1' && ` · x${nft.balance}`}
+      </span>
+    </>
+  )
+  const cardClass = 'flex flex-col gap-1 rounded-xl border border-border bg-muted/30 p-2'
+  if (explorerUrl != null)
+    return (
+      <a
+        href={`${explorerUrl}/token/${nft.contractAddress}?a=${nft.tokenId}`}
+        target='_blank'
+        rel='noopener noreferrer'
+        className={`${cardClass} transition-[border-color,transform] duration-200 ease-out hover:-translate-y-0.5 hover:border-primary/50 motion-reduce:transition-none motion-reduce:hover:translate-y-0`}
+      >
+        {card}
+      </a>
+    )
+  return <div className={cardClass}>{card}</div>
+}
+
+// Assets tab: what the wallet holds — native coin, ERC-20 tokens, and NFTs.
+// Native balance is a direct RPC read; tokens and NFTs come from the indexer
+// proxy and degrade to a note when the chain or API key does not support it.
+const MultiSigAssets: React.FC<MultiSigAssetsProps> = ({ multiSigAddress }) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { data: balance } = useBalance({ address: multiSigAddress, chainId: chain?.id })
+  const { assets, isLoading, isError, refetch } = useWalletAssets(multiSigAddress)
+
+  const explorerUrl = chain?.blockExplorers?.default?.url
+  const indexerUnavailable = assets?.notConfigured === true || assets?.unsupportedChain === true
+  const indexerNote =
+    assets?.notConfigured === true
+      ? 'Token and NFT balances need an Alchemy API key: set ALCHEMY_API_KEY on the server to enable them.'
+      : assets?.unsupportedChain === true
+        ? `Token and NFT indexing is not available on ${chain?.name ?? 'this network'}, so only the native balance is shown.`
+        : null
+
+  return (
+    <div className='flex w-full flex-col gap-4'>
+      <div className='flex flex-col gap-2 rounded-xl border border-border p-4'>
+        <div className='flex items-baseline justify-between'>
+          <h3 className='text-base font-semibold text-foreground'>Tokens</h3>
+          <Button
+            variant='ghost'
+            size='sm'
+            className='h-7 gap-1.5 px-2 text-xs text-muted-foreground'
+            onClick={() => void refetch()}
+            disabled={isLoading}
+          >
+            <RefreshIcon className='h-3.5 w-3.5' />
+            Refresh
+          </Button>
+        </div>
+        <TokenRow
+          logo={null}
+          symbol={balance?.symbol ?? chain?.nativeCurrency.symbol ?? '...'}
+          name={chain?.nativeCurrency.name ?? 'Native currency'}
+          amount={balance != null ? formatAmount(balance.value, balance.decimals) : '...'}
+          badge='native'
+        />
+        {isLoading && assets == null ? (
+          <div className='flex items-center p-2'>
+            <LoadingDots size='sm' label='Looking up token balances...' />
+          </div>
+        ) : isError || assets?.tokensError === true ? (
+          <p className='p-2 text-sm text-muted-foreground'>Could not load token balances. Try refreshing.</p>
+        ) : indexerNote != null ? (
+          <p className='p-2 text-sm text-muted-foreground'>{indexerNote}</p>
+        ) : assets != null && assets.tokens.length > 0 ? (
+          assets.tokens.map((token: TokenHolding) => (
+            <TokenRow
+              key={token.contractAddress}
+              logo={token.logo}
+              symbol={token.symbol !== '' ? token.symbol : truncate(token.contractAddress)}
+              name={token.name !== '' ? token.name : token.contractAddress}
+              amount={formatAmount(BigInt(token.balance), token.decimals)}
+              explorerHref={explorerUrl != null ? `${explorerUrl}/token/${token.contractAddress}` : undefined}
+            />
+          ))
+        ) : (
+          <p className='p-2 text-sm text-muted-foreground'>
+            No ERC-20 tokens found in this wallet. Tokens sent to {truncate(multiSigAddress)} will show up here.
+          </p>
+        )}
+      </div>
+
+      {!indexerUnavailable && (
+        <div className='flex flex-col gap-2 rounded-xl border border-border p-4'>
+          <div className='flex items-baseline justify-between'>
+            <h3 className='text-base font-semibold text-foreground'>NFTs</h3>
+            {assets != null && assets.nftTotalCount > assets.nfts.length && (
+              <span className='text-xs text-muted-foreground'>
+                showing {assets.nfts.length} of {assets.nftTotalCount}
+              </span>
+            )}
+          </div>
+          {isLoading && assets == null ? (
+            <div className='flex items-center p-2'>
+              <LoadingDots size='sm' label='Looking up NFTs...' />
+            </div>
+          ) : isError || assets?.nftsError === true ? (
+            <p className='p-2 text-sm text-muted-foreground'>Could not load NFTs. Try refreshing.</p>
+          ) : assets != null && assets.nfts.length > 0 ? (
+            <div className='grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4'>
+              {assets.nfts.map((nft) => (
+                <NftCard key={`${nft.contractAddress}-${nft.tokenId}`} nft={nft} explorerUrl={explorerUrl} />
+              ))}
+            </div>
+          ) : (
+            <p className='p-2 text-sm text-muted-foreground'>
+              No NFTs found in this wallet. Collectibles it receives will show up here.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default MultiSigAssets

--- a/src/components/multiSigDetails/MultiSigAssets.tsx
+++ b/src/components/multiSigDetails/MultiSigAssets.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { useBalance, useChainId, useChains } from 'wagmi'
-import { formatEther, formatUnits } from 'viem'
+import { useBalance, useChainId, useChains, useReadContracts } from 'wagmi'
+import { erc20Abi, formatUnits } from 'viem'
 import { Button } from '@/components/ui/button'
 import { LoadingDots } from '@/components/ui/loading-dots'
-import { CoinsIcon, ExternalLinkIcon, ImageIcon, RefreshIcon } from '../icons/ChakraIcons'
+import { AddIcon, CoinsIcon, DeleteIcon, ExternalLinkIcon, ImageIcon, RefreshIcon } from '../icons/ChakraIcons'
 
+import AddTokenModal from '../modals/AddTokenModal'
 import useWalletAssets from '../../hooks/useWalletAssets'
+import useCustomTokens from '../../states/customTokens'
 import { NftHolding, TokenHolding } from '../../models/Assets'
 
 interface MultiSigAssetsProps {
@@ -40,7 +42,8 @@ const TokenRow: React.FC<{
   amount: string
   badge?: string
   explorerHref?: string
-}> = ({ logo, symbol, name, amount, badge, explorerHref }) => (
+  onRemove?: () => void
+}> = ({ logo, symbol, name, amount, badge, explorerHref, onRemove }) => (
   <div className='flex items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-muted/40'>
     <AssetImage
       src={logo}
@@ -72,6 +75,16 @@ const TokenRow: React.FC<{
       >
         <ExternalLinkIcon className='h-3.5 w-3.5' />
       </a>
+    )}
+    {onRemove != null && (
+      <button
+        type='button'
+        onClick={onRemove}
+        aria-label={`Stop tracking ${symbol}`}
+        className='text-muted-foreground transition-colors hover:text-destructive'
+      >
+        <DeleteIcon className='h-3.5 w-3.5' />
+      </button>
     )}
   </div>
 )
@@ -119,6 +132,35 @@ const MultiSigAssets: React.FC<MultiSigAssetsProps> = ({ multiSigAddress }) => {
   const chain = chains.find((c) => c.id === chainId)
   const { data: balance } = useBalance({ address: multiSigAddress, chainId: chain?.id })
   const { assets, isLoading, isError, refetch } = useWalletAssets(multiSigAddress)
+  const { tokens: storedTokens, removeToken } = useCustomTokens()
+  const [addTokenOpen, setAddTokenOpen] = React.useState(false)
+
+  // Manually tracked tokens read their balance straight from the chain, so
+  // they stay visible even when the indexer is unavailable. allowFailure keeps
+  // one broken contract from blanking the others.
+  const customTokens = storedTokens.filter((t) => t.chainId === chain?.id)
+  const { data: customBalances, refetch: refetchCustomBalances } = useReadContracts({
+    contracts: customTokens.map((t) => ({
+      address: t.address as `0x${string}`,
+      abi: erc20Abi,
+      functionName: 'balanceOf' as const,
+      args: [multiSigAddress],
+      chainId: chain?.id
+    })),
+    query: { enabled: customTokens.length > 0 }
+  })
+
+  const refresh = () => {
+    void refetch()
+    if (customTokens.length > 0) void refetchCustomBalances()
+  }
+
+  // A custom token the indexer also reports renders once, as the removable
+  // custom row (borrowing the indexer's logo when it has one).
+  const customAddresses = new Set(customTokens.map((t) => t.address.toLowerCase()))
+  const indexedTokens = (assets?.tokens ?? []).filter((t) => !customAddresses.has(t.contractAddress.toLowerCase()))
+  const indexedLogoFor = (address: string) =>
+    assets?.tokens.find((t) => t.contractAddress.toLowerCase() === address.toLowerCase())?.logo ?? null
 
   const explorerUrl = chain?.blockExplorers?.default?.url
   const indexerUnavailable = assets?.notConfigured === true || assets?.unsupportedChain === true
@@ -134,16 +176,27 @@ const MultiSigAssets: React.FC<MultiSigAssetsProps> = ({ multiSigAddress }) => {
       <div className='flex flex-col gap-2 rounded-xl border border-border p-4'>
         <div className='flex items-baseline justify-between'>
           <h3 className='text-base font-semibold text-foreground'>Tokens</h3>
-          <Button
-            variant='ghost'
-            size='sm'
-            className='h-7 gap-1.5 px-2 text-xs text-muted-foreground'
-            onClick={() => void refetch()}
-            disabled={isLoading}
-          >
-            <RefreshIcon className='h-3.5 w-3.5' />
-            Refresh
-          </Button>
+          <div className='flex items-center gap-1'>
+            <Button
+              variant='ghost'
+              size='sm'
+              className='h-7 gap-1.5 px-2 text-xs text-muted-foreground'
+              onClick={() => setAddTokenOpen(true)}
+            >
+              <AddIcon className='h-3.5 w-3.5' />
+              Add token
+            </Button>
+            <Button
+              variant='ghost'
+              size='sm'
+              className='h-7 gap-1.5 px-2 text-xs text-muted-foreground'
+              onClick={refresh}
+              disabled={isLoading}
+            >
+              <RefreshIcon className='h-3.5 w-3.5' />
+              Refresh
+            </Button>
+          </div>
         </div>
         <TokenRow
           logo={null}
@@ -152,6 +205,27 @@ const MultiSigAssets: React.FC<MultiSigAssetsProps> = ({ multiSigAddress }) => {
           amount={balance != null ? formatAmount(balance.value, balance.decimals) : '...'}
           badge='native'
         />
+        {customTokens.map((token, index) => {
+          const read = customBalances?.[index]
+          return (
+            <TokenRow
+              key={`custom-${token.address}`}
+              logo={indexedLogoFor(token.address)}
+              symbol={token.symbol}
+              name={token.name}
+              amount={
+                read == null
+                  ? '...'
+                  : read.status === 'success'
+                    ? formatAmount(read.result as bigint, token.decimals)
+                    : '—'
+              }
+              badge='added'
+              explorerHref={explorerUrl != null ? `${explorerUrl}/token/${token.address}` : undefined}
+              onRemove={() => removeToken(token.chainId, token.address)}
+            />
+          )
+        })}
         {isLoading && assets == null ? (
           <div className='flex items-center p-2'>
             <LoadingDots size='sm' label='Looking up token balances...' />
@@ -160,8 +234,8 @@ const MultiSigAssets: React.FC<MultiSigAssetsProps> = ({ multiSigAddress }) => {
           <p className='p-2 text-sm text-muted-foreground'>Could not load token balances. Try refreshing.</p>
         ) : indexerNote != null ? (
           <p className='p-2 text-sm text-muted-foreground'>{indexerNote}</p>
-        ) : assets != null && assets.tokens.length > 0 ? (
-          assets.tokens.map((token: TokenHolding) => (
+        ) : indexedTokens.length > 0 ? (
+          indexedTokens.map((token: TokenHolding) => (
             <TokenRow
               key={token.contractAddress}
               logo={token.logo}
@@ -171,12 +245,13 @@ const MultiSigAssets: React.FC<MultiSigAssetsProps> = ({ multiSigAddress }) => {
               explorerHref={explorerUrl != null ? `${explorerUrl}/token/${token.contractAddress}` : undefined}
             />
           ))
-        ) : (
+        ) : customTokens.length === 0 ? (
           <p className='p-2 text-sm text-muted-foreground'>
             No ERC-20 tokens found in this wallet. Tokens sent to {truncate(multiSigAddress)} will show up here.
           </p>
-        )}
+        ) : null}
       </div>
+      <AddTokenModal multiSigAddress={multiSigAddress} open={addTokenOpen} onOpenChange={setAddTokenOpen} />
 
       {!indexerUnavailable && (
         <div className='flex flex-col gap-2 rounded-xl border border-border p-4'>

--- a/src/components/multiSigDetails/MultiSigNav.tsx
+++ b/src/components/multiSigDetails/MultiSigNav.tsx
@@ -10,6 +10,7 @@ interface MultiSigNavProps {
 
 const TABS = [
   { slug: '', label: 'Overview' },
+  { slug: 'assets', label: 'Assets' },
   { slug: 'buildRequest', label: 'Build a request' },
   { slug: 'requests', label: 'Requests' },
   { slug: 'activity', label: 'Activity' },

--- a/src/components/views/AddressBook.tsx
+++ b/src/components/views/AddressBook.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react'
 import { useAccount, useChainId, useChains } from 'wagmi'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { AddIcon, DeleteIcon, CheckIcon, ExternalLinkIcon } from '../icons/ChakraIcons'
+import { Switch } from '@/components/ui/switch'
+import { AddIcon, DeleteIcon, CheckIcon, ExternalLinkIcon, LockIcon, ViewIcon } from '../icons/ChakraIcons'
 
 import TextInput from '../inputs/TextInput'
 import useAddressBook, { AddressBookEntry, AddressBookEntryKind } from '../../states/addressBook'
@@ -34,11 +35,20 @@ const EntryRow: React.FC<{ entry: AddressBookEntry; explorerUrl?: string; ownerA
     if (label.trim() !== '') {
       updateEntry(entry.id, { label: label.trim() })
       persistAddressBookUpsert(
-        { chainId: entry.chainId, address: entry.address, label: label.trim(), kind: entry.kind },
+        { chainId: entry.chainId, address: entry.address, label: label.trim(), kind: entry.kind, isPublic: entry.isPublic },
         ownerAddress
       )
     }
     setEditing(false)
+  }
+
+  const toggleVisibility = () => {
+    const isPublic = entry.isPublic !== true
+    updateEntry(entry.id, { isPublic })
+    persistAddressBookUpsert(
+      { chainId: entry.chainId, address: entry.address, label: entry.label, kind: entry.kind, isPublic },
+      ownerAddress
+    )
   }
 
   const handleRemove = () => {
@@ -79,6 +89,23 @@ const EntryRow: React.FC<{ entry: AddressBookEntry; explorerUrl?: string; ownerA
         <span className={`rounded px-2 py-0.5 text-xs font-semibold ${KIND_BADGE[entry.kind]}`}>
           {entry.kind === 'contract' ? 'Contract' : 'Wallet'}
         </span>
+        <button
+          type='button'
+          onClick={toggleVisibility}
+          title={
+            entry.isPublic === true
+              ? 'Public: the MyMultiSig team can see this entry. Click to make it private.'
+              : 'Private: only you can see this entry. Click to share it publicly.'
+          }
+          className={`flex items-center gap-1 rounded px-2 py-0.5 text-xs font-semibold transition-colors ${
+            entry.isPublic === true
+              ? 'bg-primary/15 text-primary hover:bg-primary/25'
+              : 'bg-muted text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          {entry.isPublic === true ? <ViewIcon className='h-3 w-3' /> : <LockIcon className='h-3 w-3' />}
+          {entry.isPublic === true ? 'Public' : 'Private'}
+        </button>
         {explorerUrl && (
           <a
             href={`${explorerUrl}/address/${entry.address}`}
@@ -118,6 +145,7 @@ const AddressBook: React.FC<AddressBookProps> = ({ multiSigAddress }) => {
   const [newAddress, setNewAddress] = useState('')
   const [newLabel, setNewLabel] = useState('')
   const [newKind, setNewKind] = useState<AddressBookEntryKind>('wallet')
+  const [newIsPublic, setNewIsPublic] = useState(false)
 
   const chainEntries = chain != null ? entries.filter((e) => e.chainId === chain.id) : []
   const known = (address: string) => chainEntries.some((e) => e.address.toLowerCase() === address.toLowerCase())
@@ -149,12 +177,19 @@ const AddressBook: React.FC<AddressBookProps> = ({ multiSigAddress }) => {
 
   const handleAdd = () => {
     if (!canAdd || chain == null) return
-    const entry = { chainId: chain.id, address: newAddress as `0x${string}`, label: newLabel.trim(), kind: newKind }
+    const entry = {
+      chainId: chain.id,
+      address: newAddress as `0x${string}`,
+      label: newLabel.trim(),
+      kind: newKind,
+      isPublic: newIsPublic
+    }
     addEntry(entry)
     persistAddressBookUpsert(entry, connectedAddress)
     setNewAddress('')
     setNewLabel('')
     setNewKind('wallet')
+    setNewIsPublic(false)
   }
 
   return (
@@ -196,6 +231,16 @@ const AddressBook: React.FC<AddressBookProps> = ({ multiSigAddress }) => {
           </Button>
         </div>
         {duplicate && <p className='text-xs text-destructive'>This address is already in the book for this network.</p>}
+        <label className='flex items-center justify-between gap-3 rounded-lg border border-border bg-muted/30 p-3'>
+          <span className='flex flex-col gap-0.5'>
+            <span className='text-sm font-medium text-foreground'>Share publicly</span>
+            <span className='text-xs text-muted-foreground'>
+              Public entries can be seen by the MyMultiSig team, helping widely used contracts get official support.
+              Private entries stay visible to you alone.
+            </span>
+          </span>
+          <Switch checked={newIsPublic} onCheckedChange={setNewIsPublic} />
+        </label>
       </div>
 
       {suggestions.length > 0 && (

--- a/src/components/views/PublicAddressBook.stories.tsx
+++ b/src/components/views/PublicAddressBook.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import PublicAddressBook from './PublicAddressBook'
+import Web3Provider from '../web3/Web3Provider'
+
+const meta: Meta<typeof PublicAddressBook> = {
+  title: 'Views/PublicAddressBook',
+  component: PublicAddressBook
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof PublicAddressBook> = () => (
+  <Web3Provider>
+    <PublicAddressBook />
+  </Web3Provider>
+)

--- a/src/components/views/PublicAddressBook.tsx
+++ b/src/components/views/PublicAddressBook.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useState } from 'react'
+import { useChains } from 'wagmi'
+import { LoadingDots } from '@/components/ui/loading-dots'
+import { ExternalLinkIcon, LockIcon } from '../icons/ChakraIcons'
+
+import BigCard from '../cards/BigCard'
+import { getContent } from '../../utils'
+
+interface PublicEntry {
+  id: string
+  ownerAddress: string
+  chainId: number
+  address: string
+  label: string
+  kind: string
+}
+
+// One row per shared (chain, address): every label users gave it plus how
+// many distinct wallets share it — the signal for what to support officially.
+interface SharedAddress {
+  chainId: number
+  address: string
+  kind: string
+  labels: string[]
+  sharerCount: number
+}
+
+const groupEntries = (entries: PublicEntry[]): SharedAddress[] => {
+  const groups = new Map<string, SharedAddress & { sharers: Set<string> }>()
+  for (const entry of entries) {
+    const key = `${entry.chainId}-${entry.address.toLowerCase()}`
+    const group = groups.get(key) ?? {
+      chainId: entry.chainId,
+      address: entry.address,
+      kind: entry.kind,
+      labels: [],
+      sharerCount: 0,
+      sharers: new Set<string>()
+    }
+    if (!group.labels.includes(entry.label)) group.labels.push(entry.label)
+    group.sharers.add(entry.ownerAddress.toLowerCase())
+    if (entry.kind === 'contract') group.kind = 'contract'
+    groups.set(key, group)
+  }
+  return Array.from(groups.values())
+    .map(({ sharers, ...group }) => ({ ...group, sharerCount: sharers.size }))
+    .sort((a, b) => b.sharerCount - a.sharerCount)
+}
+
+// Admin-only review of publicly shared address book entries. The API rejects
+// wallets outside ADMIN_ADDRESSES, so this page degrades to an explanation
+// for everyone else.
+const PublicAddressBook: React.FC = () => {
+  const chains = useChains()
+  const [entries, setEntries] = useState<PublicEntry[] | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [deniedMessage, setDeniedMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const response = await getContent({ action: 'getPublicAddressBook', data: {} })
+        if (response != null && Array.isArray(response.content)) {
+          setEntries(response.content as PublicEntry[])
+        } else {
+          setDeniedMessage(typeof response?.message === 'string' ? response.message : 'Could not load entries.')
+        }
+      } catch {
+        setDeniedMessage('Could not load entries.')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    void load()
+  }, [])
+
+  const shared = entries != null ? groupEntries(entries) : []
+
+  return (
+    <BigCard className='max-w-[1200px]'>
+      <div className='flex w-full flex-col gap-6'>
+        <div>
+          <h2 className='font-display text-2xl font-bold tracking-tight text-foreground'>Public address book</h2>
+          <p className='text-sm text-muted-foreground'>
+            Addresses users chose to share publicly, grouped across chains. The more wallets share a contract, the
+            stronger the case for supporting it officially.
+          </p>
+        </div>
+
+        {isLoading ? (
+          <div className='flex items-center justify-center p-6'>
+            <LoadingDots label='Loading public entries...' />
+          </div>
+        ) : deniedMessage != null ? (
+          <div className='flex items-center gap-3 rounded-xl border border-border bg-muted/30 p-4'>
+            <LockIcon className='h-5 w-5 shrink-0 text-muted-foreground' />
+            <div className='flex flex-col gap-0.5'>
+              <span className='text-sm font-semibold text-foreground'>Admins only</span>
+              <span className='text-sm text-muted-foreground'>
+                {deniedMessage.endsWith('.') ? deniedMessage : `${deniedMessage}.`} Sign in with a wallet listed in
+                ADMIN_ADDRESSES to review shared entries.
+              </span>
+            </div>
+          </div>
+        ) : shared.length === 0 ? (
+          <p className='text-sm text-muted-foreground'>
+            No public entries yet. Entries appear here once users mark address book items as public.
+          </p>
+        ) : (
+          <div className='flex flex-col gap-2'>
+            {shared.map((item) => {
+              const chain = chains.find((c) => c.id === item.chainId)
+              const explorerUrl = chain?.blockExplorers?.default?.url
+              return (
+                <div
+                  key={`${item.chainId}-${item.address}`}
+                  className='flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border p-3'
+                >
+                  <div className='flex min-w-0 flex-col gap-0.5'>
+                    <span className='text-sm font-semibold text-foreground'>{item.labels.join(' · ')}</span>
+                    <span className='break-all font-mono text-xs text-muted-foreground'>{item.address}</span>
+                  </div>
+                  <div className='flex shrink-0 items-center gap-2'>
+                    <span className='rounded bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground'>
+                      {chain?.name ?? `Chain ${item.chainId}`}
+                    </span>
+                    <span
+                      className={`rounded px-2 py-0.5 text-xs font-semibold ${
+                        item.kind === 'contract' ? 'bg-muted text-muted-foreground' : 'bg-primary/15 text-primary'
+                      }`}
+                    >
+                      {item.kind === 'contract' ? 'Contract' : 'Wallet'}
+                    </span>
+                    <span className='rounded bg-primary/15 px-2 py-0.5 text-xs font-semibold text-primary'>
+                      shared by {item.sharerCount} {item.sharerCount === 1 ? 'user' : 'users'}
+                    </span>
+                    {explorerUrl != null && (
+                      <a
+                        href={`${explorerUrl}/address/${item.address}`}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        aria-label='View on explorer'
+                        className='text-muted-foreground transition-colors hover:text-primary'
+                      >
+                        <ExternalLinkIcon className='h-3.5 w-3.5' />
+                      </a>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </BigCard>
+  )
+}
+
+export default PublicAddressBook

--- a/src/constants/alchemyNetworks.ts
+++ b/src/constants/alchemyNetworks.ts
@@ -1,0 +1,25 @@
+// Alchemy network slugs for the chains in networks.ts that Alchemy indexes.
+// Chains missing here (mostly deprecated testnets) fall back to native-balance-only
+// display in the Assets tab, since enumerating tokens/NFTs needs an indexer.
+const alchemyNetworks: Record<number, string> = {
+  // Ethereum
+  1: 'eth-mainnet',
+  11155111: 'eth-sepolia',
+  // Polygon
+  137: 'polygon-mainnet',
+  // Optimism
+  10: 'opt-mainnet',
+  // Arbitrum
+  42161: 'arb-mainnet',
+  // Avalanche
+  43114: 'avax-mainnet',
+  43113: 'avax-fuji',
+  // BNB Chain
+  56: 'bnb-mainnet',
+  // Gnosis
+  100: 'gnosis-mainnet'
+}
+
+export const alchemyNetworkSlug = (chainId: number): string | undefined => alchemyNetworks[chainId]
+
+export default alchemyNetworks

--- a/src/hooks/useWalletAssets.ts
+++ b/src/hooks/useWalletAssets.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useChainId, useChains } from 'wagmi'
+
+import { WalletAssets } from '../models/Assets'
+import { getAssets } from '../utils'
+
+// Token and NFT holdings for any address on the current chain, via the
+// server-side indexer proxy (/api/get-assets). Native balance stays a direct
+// wagmi useBalance read in the consuming component.
+const useWalletAssets = (address: `0x${string}`) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const [assets, setAssets] = useState<WalletAssets | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isError, setIsError] = useState(false)
+
+  const fetchAssets = useCallback(async () => {
+    if (!chain) return
+    setIsLoading(true)
+    setIsError(false)
+    try {
+      const data = await getAssets({ action: 'getWalletAssets', data: { address, chainId: chain.id } })
+      if (data != null && data.content != null) {
+        setAssets(data.content as WalletAssets)
+      } else {
+        setIsError(true)
+      }
+    } catch {
+      setIsError(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [chain, address])
+
+  useEffect(() => {
+    setAssets(null)
+    void fetchAssets()
+  }, [fetchAssets])
+
+  return { assets, isLoading, isError, refetch: fetchAssets }
+}
+
+export default useWalletAssets

--- a/src/lib/auth/siwe.ts
+++ b/src/lib/auth/siwe.ts
@@ -106,3 +106,16 @@ export const isVerifiedAs = (req: NextApiRequest, claimed: string | undefined | 
   const verified = getVerifiedAddress(req)
   return verified != null && verified === String(claimed).toLowerCase()
 }
+
+// MyMultiSig admin wallets, from the ADMIN_ADDRESSES env var (comma-separated).
+// Admins can read publicly shared address book entries to decide which
+// contracts to support officially.
+const adminAddresses = (process.env.ADMIN_ADDRESSES ?? '')
+  .split(',')
+  .map((address) => address.trim().toLowerCase())
+  .filter((address) => address !== '')
+
+export const isVerifiedAdmin = (req: NextApiRequest): boolean => {
+  const verified = getVerifiedAddress(req)
+  return verified != null && adminAddresses.includes(verified)
+}

--- a/src/lib/db/schema.sql
+++ b/src/lib/db/schema.sql
@@ -57,8 +57,14 @@ CREATE TABLE IF NOT EXISTS address_book (
   address TEXT NOT NULL,
   label TEXT NOT NULL,
   kind TEXT NOT NULL DEFAULT 'wallet',
+  is_public BOOLEAN NOT NULL DEFAULT false,
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
+
+-- Idempotent migration for databases created before entry visibility existed.
+-- Public entries are readable by MyMultiSig admins (see getPublicAddressBook)
+-- so widely shared contracts can be reviewed for official support.
+ALTER TABLE address_book ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT false;
 
 -- One label per (owner, chain, address); upserts key on this.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_address_book_owner_chain_address

--- a/src/models/Assets.ts
+++ b/src/models/Assets.ts
@@ -1,0 +1,29 @@
+export interface TokenHolding {
+  contractAddress: string
+  // Raw balance in base units as a decimal string; format with `decimals`.
+  balance: string
+  decimals: number
+  symbol: string
+  name: string
+  logo: string | null
+}
+
+export interface NftHolding {
+  contractAddress: string
+  tokenId: string
+  tokenType: string
+  name: string | null
+  collectionName: string | null
+  imageUrl: string | null
+  balance: string
+}
+
+export interface WalletAssets {
+  tokens: TokenHolding[]
+  nfts: NftHolding[]
+  nftTotalCount: number
+  tokensError: boolean
+  nftsError: boolean
+  notConfigured?: boolean
+  unsupportedChain?: boolean
+}

--- a/src/models/Assets.ts
+++ b/src/models/Assets.ts
@@ -18,6 +18,16 @@ export interface NftHolding {
   balance: string
 }
 
+// A token the user tracks manually; its balance is read straight from the
+// chain, so it works even without indexer coverage.
+export interface CustomToken {
+  chainId: number
+  address: string
+  symbol: string
+  name: string
+  decimals: number
+}
+
 export interface WalletAssets {
   tokens: TokenHolding[]
   nfts: NftHolding[]

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import PublicAddressBook from '../components/views/PublicAddressBook'
+
+const Page: React.FC = () => {
+  return <PublicAddressBook />
+}
+
+export async function getStaticProps() {
+  return { props: { title: 'MyMultiSig - Admin' } }
+}
+
+export default Page

--- a/src/pages/api/add-content.ts
+++ b/src/pages/api/add-content.ts
@@ -161,13 +161,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         `) as { id: string }[]
         if (existing.length > 0) {
           await sql`
-            UPDATE address_book SET label = ${doc.label}, kind = ${doc.kind ?? 'wallet'}
+            UPDATE address_book SET label = ${doc.label}, kind = ${doc.kind ?? 'wallet'}, is_public = ${doc.isPublic ?? false}
             WHERE id = ${existing[0].id}
           `
         } else {
           await sql`
-            INSERT INTO address_book (id, owner_address, chain_id, address, label, kind)
-            VALUES (${uuid()}, ${doc.ownerAddress}, ${doc.chainId}, ${doc.address}, ${doc.label}, ${doc.kind ?? 'wallet'})
+            INSERT INTO address_book (id, owner_address, chain_id, address, label, kind, is_public)
+            VALUES (${uuid()}, ${doc.ownerAddress}, ${doc.chainId}, ${doc.address}, ${doc.label}, ${doc.kind ?? 'wallet'}, ${doc.isPublic ?? false})
           `
         }
         console.log('Address book upsert done')

--- a/src/pages/api/get-assets.ts
+++ b/src/pages/api/get-assets.ts
@@ -1,0 +1,145 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import { alchemyNetworkSlug } from '../../constants/alchemyNetworks'
+import { NftHolding, TokenHolding } from '../../models/Assets'
+
+const FUNCTION = 'get-assets'
+
+// Caps keep a single request bounded; wallets holding more than this show a
+// "showing first N" hint client-side (NFT totalCount is returned separately).
+const MAX_TOKENS = 50
+const MAX_NFTS = 50
+
+// Assets are public on-chain data keyed only by address + chain, so like
+// getABI this route needs no SIWE session — it only keeps the key server-side.
+const apiKey = process.env.ALCHEMY_API_KEY ?? process.env.NEXT_PUBLIC_ALCHEMY_API_KEY
+
+interface RawTokenBalance {
+  contractAddress: string
+  tokenBalance: string | null
+  error?: string | null
+}
+
+const fetchTokens = async (slug: string, address: string): Promise<TokenHolding[]> => {
+  const rpcUrl = `https://${slug}.g.alchemy.com/v2/${apiKey}`
+  const balanceRes = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'alchemy_getTokenBalances', params: [address, 'erc20'] })
+  })
+  if (!balanceRes.ok) throw new Error(`Token balances request failed (${balanceRes.status})`)
+  const balanceJson = await balanceRes.json()
+  if (balanceJson.error != null) throw new Error(String(balanceJson.error.message ?? 'Token balances RPC error'))
+
+  const rawBalances: RawTokenBalance[] = Array.isArray(balanceJson.result?.tokenBalances)
+    ? balanceJson.result.tokenBalances
+    : []
+  const held = rawBalances
+    .filter((t) => t.error == null && t.tokenBalance != null && BigInt(t.tokenBalance) > 0n)
+    .slice(0, MAX_TOKENS)
+  if (held.length === 0) return []
+
+  // One batched JSON-RPC call for all metadata; ids map answers back to tokens.
+  const metadataRes = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(
+      held.map((t, i) => ({ jsonrpc: '2.0', id: i, method: 'alchemy_getTokenMetadata', params: [t.contractAddress] }))
+    )
+  })
+  if (!metadataRes.ok) throw new Error(`Token metadata request failed (${metadataRes.status})`)
+  const metadataJson = await metadataRes.json()
+  const metadataById = new Map<number, Record<string, unknown>>()
+  if (Array.isArray(metadataJson)) {
+    for (const entry of metadataJson) {
+      if (entry?.result != null) metadataById.set(Number(entry.id), entry.result)
+    }
+  }
+
+  return held
+    .map((t, i) => {
+      const metadata = metadataById.get(i)
+      return {
+        contractAddress: t.contractAddress,
+        balance: BigInt(t.tokenBalance as string).toString(),
+        decimals: Number(metadata?.decimals ?? 18),
+        symbol: String(metadata?.symbol ?? ''),
+        name: String(metadata?.name ?? ''),
+        logo: metadata?.logo != null ? String(metadata.logo) : null
+      }
+    })
+    // Entries without a symbol or name are unreadable (often spam); drop them.
+    .filter((t) => t.symbol !== '' || t.name !== '')
+}
+
+const fetchNfts = async (slug: string, address: string): Promise<{ nfts: NftHolding[]; totalCount: number }> => {
+  const nftUrl =
+    `https://${slug}.g.alchemy.com/nft/v3/${apiKey}/getNFTsForOwner` +
+    `?owner=${address}&withMetadata=true&pageSize=${MAX_NFTS}`
+  const res = await fetch(nftUrl)
+  if (!res.ok) throw new Error(`NFT request failed (${res.status})`)
+  const json = await res.json()
+  const owned: Record<string, any>[] = Array.isArray(json.ownedNfts) ? json.ownedNfts : []
+  const nfts = owned.map((nft) => ({
+    contractAddress: String(nft.contract?.address ?? ''),
+    tokenId: String(nft.tokenId ?? ''),
+    tokenType: String(nft.tokenType ?? nft.contract?.tokenType ?? ''),
+    name: nft.name != null ? String(nft.name) : null,
+    collectionName: nft.contract?.name != null ? String(nft.contract.name) : null,
+    imageUrl:
+      nft.image?.thumbnailUrl != null
+        ? String(nft.image.thumbnailUrl)
+        : nft.image?.cachedUrl != null
+          ? String(nft.image.cachedUrl)
+          : null,
+    balance: String(nft.balance ?? '1')
+  }))
+  return { nfts, totalCount: Number(json.totalCount ?? nfts.length) }
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  console.log('Function `%s` invoked', FUNCTION)
+  const data = JSON.parse(req.body)
+  if (data.action !== 'getWalletAssets' || data.data === undefined) {
+    return res.status(400).json({ message: 'Invalid data' })
+  }
+  const { address, chainId } = data.data
+  if (typeof address !== 'string' || !/^0x[a-fA-F0-9]{40}$/.test(address) || typeof chainId !== 'number') {
+    return res.status(400).json({ message: 'Invalid address or chainId' })
+  }
+
+  // The key is optional (see .env.example); degrade instead of failing at boot
+  // like routes whose whole feature depends on their key.
+  if (apiKey == null || apiKey === '') {
+    return res.status(200).json({
+      message: 'Indexer not configured',
+      content: { tokens: [], nfts: [], nftTotalCount: 0, tokensError: false, nftsError: false, notConfigured: true }
+    })
+  }
+  const slug = alchemyNetworkSlug(chainId)
+  if (slug === undefined) {
+    return res.status(200).json({
+      message: 'Chain not supported by indexer',
+      content: { tokens: [], nfts: [], nftTotalCount: 0, tokensError: false, nftsError: false, unsupportedChain: true }
+    })
+  }
+
+  // Tokens and NFTs fail independently (NFT API coverage varies by chain), so
+  // one side erroring still returns the other.
+  const [tokensResult, nftsResult] = await Promise.allSettled([fetchTokens(slug, address), fetchNfts(slug, address)])
+  if (tokensResult.status === 'rejected') console.log('Token fetch failed:', tokensResult.reason)
+  if (nftsResult.status === 'rejected') console.log('NFT fetch failed:', nftsResult.reason)
+
+  return res.status(200).json({
+    message: 'Data retrieved',
+    content: {
+      tokens: tokensResult.status === 'fulfilled' ? tokensResult.value : [],
+      nfts: nftsResult.status === 'fulfilled' ? nftsResult.value.nfts : [],
+      nftTotalCount: nftsResult.status === 'fulfilled' ? nftsResult.value.totalCount : 0,
+      tokensError: tokensResult.status === 'rejected',
+      nftsError: nftsResult.status === 'rejected'
+    }
+  })
+}
+
+export default handler

--- a/src/pages/api/get-content.ts
+++ b/src/pages/api/get-content.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { getSql } from '../../lib/db/neon'
 import { rowToMultiSigRequest, rowToMultiSig } from '../../lib/db/mappers'
-import { isVerifiedAs } from '../../lib/auth/siwe'
+import { isVerifiedAdmin, isVerifiedAs } from '../../lib/auth/siwe'
 
 if (!process.env.DATABASE_URL) throw new Error('No DATABASE_URL in .env file')
 
@@ -108,11 +108,37 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         }
         // All chains at once so a network switch client-side needs no refetch.
         const rows = (await sql`
-          SELECT id, chain_id, address, label, kind FROM address_book
+          SELECT id, chain_id, address, label, kind, is_public FROM address_book
           WHERE LOWER(owner_address) = LOWER(${data.data.ownerAddress})
         `) as Record<string, unknown>[]
         const content = rows.map((row) => ({
           id: String(row.id),
+          chainId: Number(row.chain_id),
+          address: String(row.address),
+          label: String(row.label),
+          kind: String(row.kind),
+          isPublic: Boolean(row.is_public)
+        }))
+        return res.status(200).json({
+          message: 'Data retrieved',
+          content
+        })
+      }
+      case 'getPublicAddressBook': {
+        // Entries users chose to share, across all owners and chains, so
+        // MyMultiSig admins can see which contracts the community relies on
+        // and decide what to support officially. Admin wallets only.
+        if (!isVerifiedAdmin(req)) {
+          return res.status(403).json({ message: 'Only MyMultiSig admins can view the public address book' })
+        }
+        const rows = (await sql`
+          SELECT id, owner_address, chain_id, address, label, kind FROM address_book
+          WHERE is_public = true
+          ORDER BY created_at DESC
+        `) as Record<string, unknown>[]
+        const content = rows.map((row) => ({
+          id: String(row.id),
+          ownerAddress: String(row.owner_address),
           chainId: Number(row.chain_id),
           address: String(row.address),
           label: String(row.label),

--- a/src/pages/multisig/[multisigAddress]/assets.tsx
+++ b/src/pages/multisig/[multisigAddress]/assets.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { useRouter } from 'next/router'
+import { useAccount } from 'wagmi'
+
+import MultiSigPageLayout from '../../../components/multiSigDetails/MultiSigPageLayout'
+import MultiSigAssets from '../../../components/multiSigDetails/MultiSigAssets'
+
+const Page: React.FC = () => {
+  const router = useRouter()
+  const { multisigAddress } = router.query
+  const { address } = useAccount()
+
+  if (address == null || multisigAddress == null || Array.isArray(multisigAddress) || !multisigAddress.startsWith('0x'))
+    return null
+
+  return (
+    <MultiSigPageLayout multiSigAddress={multisigAddress as `0x${string}`}>
+      <MultiSigAssets multiSigAddress={multisigAddress as `0x${string}`} />
+    </MultiSigPageLayout>
+  )
+}
+
+export async function getStaticProps() {
+  return { props: { title: 'MyMultiSig - Assets' } }
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [{ params: { multisigAddress: '0x' } }],
+    fallback: true
+  }
+}
+
+export default Page

--- a/src/states/addressBook.ts
+++ b/src/states/addressBook.ts
@@ -10,6 +10,10 @@ export type AddressBookEntry = {
   address: `0x${string}`
   label: string
   kind: AddressBookEntryKind
+  // Public entries may be reviewed by MyMultiSig admins so widely shared
+  // contracts can be officially supported. Optional so entries persisted
+  // before the flag existed stay valid; absent means private.
+  isPublic?: boolean
 }
 
 interface AddressBookDefaultState {

--- a/src/states/customTokens.ts
+++ b/src/states/customTokens.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+import { CustomToken } from '../models/Assets'
+
+interface CustomTokensDefaultState {
+  tokens: CustomToken[]
+}
+
+interface CustomTokensState extends CustomTokensDefaultState {
+  addToken: (token: CustomToken) => void
+  removeToken: (chainId: number, address: string) => void
+  clearTokens: () => void
+}
+
+const initialState: CustomTokensDefaultState = {
+  tokens: []
+}
+
+const sameToken = (token: CustomToken, chainId: number, address: string) =>
+  token.chainId === chainId && token.address.toLowerCase() === address.toLowerCase()
+
+const useCustomTokens = create<CustomTokensState>()(
+  persist(
+    (set) => ({
+      ...initialState,
+      addToken: (token) =>
+        set((state) => ({
+          tokens: [...state.tokens.filter((t) => !sameToken(t, token.chainId, token.address)), token]
+        })),
+      removeToken: (chainId, address) =>
+        set((state) => ({
+          tokens: state.tokens.filter((t) => !sameToken(t, chainId, address))
+        })),
+      clearTokens: () => set(() => ({ ...initialState }))
+    }),
+    {
+      name: 'custom-tokens-storage',
+      storage: createJSONStorage(() => localStorage)
+    }
+  )
+)
+
+export default useCustomTokens

--- a/src/utils/addressBookSync.ts
+++ b/src/utils/addressBookSync.ts
@@ -47,7 +47,8 @@ export const syncAddressBookWithRemote = async (ownerAddress: string, chainId: n
           chainId: e.chainId,
           address: e.address,
           label: e.label,
-          kind: e.kind === 'contract' ? 'contract' : 'wallet'
+          kind: e.kind === 'contract' ? 'contract' : 'wallet',
+          isPublic: e.isPublic === true
         })
       )
     entries.filter((e) => !remoteKeys.has(localKey(e))).forEach((e) => persistAddressBookUpsert(e, ownerAddress))

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -29,6 +29,15 @@ const getABI = (data: object) => {
   })
 }
 
+const getAssets = (data: object) => {
+  return fetch('/api/get-assets', {
+    body: JSON.stringify(data),
+    method: 'POST'
+  }).then((response) => {
+    return response.json()
+  })
+}
+
 const getContent = (data: object) => {
   return fetch('/api/get-content', {
     body: JSON.stringify(data),
@@ -57,4 +66,4 @@ const deleteContent = (data: object, documentId: string) => {
   }).then(handleContentResponse)
 }
 
-export { verifyContract, getABI, addContent, deleteContent, getContent, updateContent }
+export { verifyContract, getABI, addContent, deleteContent, getAssets, getContent, updateContent }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
 import truncateAddress from './truncateAddress'
 
-export { verifyContract, getABI, addContent, deleteContent, getContent, updateContent } from './api'
+export { verifyContract, getABI, addContent, deleteContent, getAssets, getContent, updateContent } from './api'
 export { truncateAddress }


### PR DESCRIPTION
## Summary

Adds an **Assets** tab to the multisig wallet page showing everything the wallet holds, plus address-book sharing with admin review:

- **Tokens card** — always leads with the native balance (direct wagmi `useBalance` read, works on every chain), followed by ERC-20 holdings with logo, name, formatted balance, and a block-explorer link per token.
- **Add token** — MetaMask-style import: paste an ERC-20 contract address, the modal reads symbol/decimals/name/balance live from the chain to validate it, and the token is persisted per chain (Zustand + localStorage). Tracked tokens read `balanceOf` directly over RPC, so they work even on chains without indexer coverage, and can be removed from the list. The modal also offers to **save the token to the address book**, with a public/private choice.
- **NFTs card** — responsive grid of collectibles with image fallbacks, collection + token id captions, ERC-1155 quantity badges, and a "showing N of M" hint when holdings exceed the 50-item page.
- **Address book visibility** — entries gain an `is_public` flag (private by default; idempotent column migration in `schema.sql`). Users choose visibility when adding an entry and can toggle any entry between Private/Public afterward; the flag syncs through the existing two-way Neon sync.
- **Admin review (`/admin`)** — wallets listed in the new `ADMIN_ADDRESSES` env var can view all publicly shared entries via a new `getPublicAddressBook` action, grouped by chain + address with a distinct-sharer count — the signal for which contracts MyMultiSig should support officially. Everyone else gets an "Admins only" explanation (403; the action never exposes private entries).

### How it works

- Token/NFT enumeration is impractical over raw RPC, so a new server-side route `/api/get-assets` proxies Alchemy's token (`alchemy_getTokenBalances` + batched `alchemy_getTokenMetadata`) and NFT (`getNFTsForOwner` v3) APIs, keeping the key server-side (`ALCHEMY_API_KEY`, falling back to `NEXT_PUBLIC_ALCHEMY_API_KEY`).
- Holdings are public on-chain data keyed only by address + chain, so like `/api/getABI` the route needs no SIWE session.
- Graceful degradation: no API key, an Alchemy-unsupported chain (deprecated testnets), or a partial upstream failure each produce an explanatory note instead of an error — the native balance and manually added tokens stay visible in all cases.
- Admin gating reuses the SIWE session: `isVerifiedAdmin` in `src/lib/auth/siwe.ts` checks the verified wallet against `ADMIN_ADDRESSES` (comma-separated, server-side only).
- New chainId → Alchemy slug map in `src/constants/alchemyNetworks.ts`, `useWalletAssets` hook following the `useMultiSigRequests` pattern, `customTokens` Zustand store following the `contracts` store pattern, and `.stories.tsx` files per component convention.

### Deployment notes

- Run the updated `src/lib/db/schema.sql` against Neon (adds `address_book.is_public`, idempotent).
- Set `ALCHEMY_API_KEY` (Assets tab indexing) and `ADMIN_ADDRESSES` (admin review) in the environment.

### Verification

- `yarn build` passes.
- Driven headlessly against the production build with an injected wallet on an anvil Sepolia fork:
  - not-configured path renders the native row + explanatory note (no NFT card);
  - stubbed happy path renders token rows (incl. logo fallback icons), explorer links, NFT grid with placeholders, "showing 2 of 8", and `x5` ERC-1155 badge;
  - add-token flow verified end-to-end against real Sepolia LINK (seeded via `anvil_setStorageAt`): live preview, "added" badge row, survives reload, duplicate blocked, remove works;
  - add-token → address book flow: both switches render, combined toast fires, LINK appears on the Address book tab with Contract + Public badges, and the badge toggles back to Private;
  - `/admin` without an admin session renders the "Admins only" explanation instead of data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)