### PR TITLE
feat(seo): round 2 — error-page noindex, kebab-case routes, networks page, docs guides

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,12 @@ const nextConfig = {
   experimental: {},
   images: {},
   reactStrictMode: true,
+  // Old camelCase routes — permanent redirects preserve inbound links and SEO equity
+  redirects: async () => [
+    { source: '/createMultiSig', destination: '/create-multisig', permanent: true },
+    { source: '/useYourMultiSig', destination: '/open-multisig', permanent: true },
+    { source: '/importMultiSig', destination: '/import-multisig', permanent: true }
+  ],
   // mymultisig-contract ships its constants as raw .ts
   transpilePackages: ['mymultisig-contract'],
   webpack: (config) => {

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -13,19 +13,19 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://mymultisig.app/createMultiSig</loc>
+    <loc>https://mymultisig.app/create-multisig</loc>
     <lastmod>2026-07-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://mymultisig.app/useYourMultiSig</loc>
+    <loc>https://mymultisig.app/open-multisig</loc>
     <lastmod>2026-07-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://mymultisig.app/importMultiSig</loc>
+    <loc>https://mymultisig.app/import-multisig</loc>
     <lastmod>2026-07-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -31,6 +31,42 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://mymultisig.app/networks</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://mymultisig.app/docs</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://mymultisig.app/docs/what-is-a-multisig</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://mymultisig.app/docs/create-a-multisig</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://mymultisig.app/docs/propose-sign-execute</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://mymultisig.app/docs/import-a-multisig</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://mymultisig.app/integration</loc>
     <lastmod>2026-07-16</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/components/docs/GuideLayout.stories.tsx
+++ b/src/components/docs/GuideLayout.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import GuideLayout, { GuideSection, GuideText, GuideSteps, GuideNote } from './GuideLayout'
+
+const meta: Meta<typeof GuideLayout> = {
+  title: 'Docs/GuideLayout',
+  component: GuideLayout,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof GuideLayout> = () => (
+  <GuideLayout
+    kicker="GUIDE"
+    title="Example guide"
+    lead="A short lead paragraph that frames what this guide covers."
+    related={[{ title: 'Another guide', href: '/docs' }]}
+  >
+    <GuideSection title="First section">
+      <GuideText>
+        Body copy with a <strong>bold term</strong> inline.
+      </GuideText>
+      <GuideSteps>
+        <li>First step of the flow.</li>
+        <li>Second step of the flow.</li>
+      </GuideSteps>
+      <GuideNote>
+        <strong>Note:</strong> callout style for warnings and caveats.
+      </GuideNote>
+    </GuideSection>
+  </GuideLayout>
+)

--- a/src/components/docs/GuideLayout.tsx
+++ b/src/components/docs/GuideLayout.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import Link from 'next/link'
+import { ArrowBackIcon } from '../icons/ChakraIcons'
+
+export interface RelatedGuide {
+  title: string
+  href: string
+}
+
+interface GuideLayoutProps {
+  kicker: string
+  title: string
+  lead: string
+  related?: RelatedGuide[]
+  children: React.ReactNode
+}
+
+/** Section with an h2 heading; body copy goes in children (use GuideText / GuideList / GuideSteps). */
+export const GuideSection: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+  <section className="flex flex-col gap-3">
+    <h2 className="font-display text-xl font-semibold tracking-tight text-foreground">{title}</h2>
+    {children}
+  </section>
+)
+
+export const GuideText: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <p className="text-sm leading-relaxed text-muted-foreground [&_a]:text-primary [&_a]:underline-offset-4 [&_a:hover]:underline [&_strong]:font-semibold [&_strong]:text-foreground">
+    {children}
+  </p>
+)
+
+export const GuideList: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ul className="flex list-disc flex-col gap-2 pl-5 text-sm leading-relaxed text-muted-foreground [&_a]:text-primary [&_a]:underline-offset-4 [&_a:hover]:underline [&_strong]:font-semibold [&_strong]:text-foreground">
+    {children}
+  </ul>
+)
+
+/** Numbered steps — pairs with HowTo structured data on the page. */
+export const GuideSteps: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ol className="flex list-decimal flex-col gap-3 pl-5 text-sm leading-relaxed text-muted-foreground marker:font-mono marker:text-primary [&_a]:text-primary [&_a]:underline-offset-4 [&_a:hover]:underline [&_strong]:font-semibold [&_strong]:text-foreground">
+    {children}
+  </ol>
+)
+
+export const GuideNote: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 text-sm leading-relaxed text-muted-foreground [&_strong]:font-semibold [&_strong]:text-foreground">
+    {children}
+  </div>
+)
+
+const GuideLayout: React.FC<GuideLayoutProps> = ({ kicker, title, lead, related, children }) => {
+  return (
+    <div className="flex justify-center">
+      <article className="flex w-full max-w-[760px] flex-col gap-8 py-4 md:py-8">
+        <div>
+          <Link
+            href="/docs"
+            className="mb-6 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowBackIcon boxSize={14} className="shrink-0" />
+            All guides
+          </Link>
+          <p className="mb-3 font-mono text-xs tracking-[0.2em] text-primary">{kicker}</p>
+          <h1 className="mb-4 font-display text-3xl font-bold leading-tight tracking-tight text-foreground md:text-4xl">
+            {title}
+          </h1>
+          <p className="text-lg font-medium leading-relaxed text-foreground">{lead}</p>
+        </div>
+
+        {children}
+
+        {related && related.length > 0 && (
+          <nav aria-label="Related guides" className="flex flex-col gap-3 border-t border-border pt-6">
+            <h2 className="font-mono text-xs uppercase tracking-wider text-muted-foreground/70">Keep reading</h2>
+            <ul className="flex flex-col gap-2">
+              {related.map((guide) => (
+                <li key={guide.href}>
+                  <Link
+                    href={guide.href}
+                    className="text-sm font-medium text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline"
+                  >
+                    {guide.title}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
+      </article>
+    </div>
+  )
+}
+
+export default GuideLayout

--- a/src/components/footer/FooterBox.tsx
+++ b/src/components/footer/FooterBox.tsx
@@ -28,6 +28,8 @@ const footerColumns: FooterColumn[] = [
   {
     title: 'Resources',
     items: [
+      { name: 'Guides', href: '/docs' },
+      { name: 'Supported networks', href: '/networks' },
       { name: 'App code', href: 'https://github.com/marc-aurele-besner/mymultisig-app', external: true },
       { name: 'Contract code', href: 'https://github.com/marc-aurele-besner/mymultisig-contract', external: true },
       { name: 'npm package', href: 'https://www.npmjs.com/package/mymultisig-contract', external: true },

--- a/src/components/footer/FooterBox.tsx
+++ b/src/components/footer/FooterBox.tsx
@@ -18,9 +18,9 @@ const footerColumns: FooterColumn[] = [
   {
     title: 'App',
     items: [
-      { name: 'Create a multisig', href: '/createMultiSig' },
-      { name: 'Import a multisig', href: '/importMultiSig' },
-      { name: 'Open existing multisig', href: '/useYourMultiSig' },
+      { name: 'Create a multisig', href: '/create-multisig' },
+      { name: 'Import a multisig', href: '/import-multisig' },
+      { name: 'Open existing multisig', href: '/open-multisig' },
       { name: 'Integration', href: '/integration' },
       { name: 'About', href: '/about' }
     ]

--- a/src/components/header/HeaderBox.tsx
+++ b/src/components/header/HeaderBox.tsx
@@ -42,9 +42,9 @@ const HeaderBox: React.FC = () => {
   const [sheetOpen, setSheetOpen] = useState(false)
 
   const menu = [
-    { name: 'Create', link: '/createMultiSig', icon: <AddIcon boxSize={16} className='shrink-0' /> },
-    { name: 'Import', link: '/importMultiSig', icon: <ImportIcon boxSize={16} className='shrink-0' /> },
-    { name: 'My multisigs', link: '/useYourMultiSig', icon: <WalletIcon boxSize={16} className='shrink-0' /> },
+    { name: 'Create', link: '/create-multisig', icon: <AddIcon boxSize={16} className='shrink-0' /> },
+    { name: 'Import', link: '/import-multisig', icon: <ImportIcon boxSize={16} className='shrink-0' /> },
+    { name: 'My multisigs', link: '/open-multisig', icon: <WalletIcon boxSize={16} className='shrink-0' /> },
     { name: 'Integration', link: '/integration', icon: <LinkIcon boxSize={16} className='shrink-0' /> },
     { name: 'About', link: '/about', icon: <InfoOutlineIcon boxSize={16} className='shrink-0' /> }
   ]

--- a/src/components/icons/ChakraIcons.tsx
+++ b/src/components/icons/ChakraIcons.tsx
@@ -23,6 +23,7 @@ import {
   Link as LinkIconLucide,
   Info as InfoIconLucide,
   ArrowLeft as ArrowLeftIconLucide,
+  ArrowRight as ArrowRightIconLucide,
   Coins as CoinsIconLucide,
   Image as ImageIconLucide,
   RefreshCw as RefreshIconLucide,
@@ -69,6 +70,7 @@ export const LinkIcon = withIcon(LinkIconLucide, 'LinkIcon')
 export const InfoIcon = withIcon(InfoIconLucide, 'InfoIcon')
 export const InfoOutlineIcon = withIcon(InfoIconLucide, 'InfoOutlineIcon')
 export const ArrowBackIcon = withIcon(ArrowLeftIconLucide, 'ArrowBackIcon')
+export const ArrowForwardIcon = withIcon(ArrowRightIconLucide, 'ArrowForwardIcon')
 export const CoinsIcon = withIcon(CoinsIconLucide, 'CoinsIcon')
 export const ImageIcon = withIcon(ImageIconLucide, 'ImageIcon')
 export const RefreshIcon = withIcon(RefreshIconLucide, 'RefreshIcon')

--- a/src/components/views/About.tsx
+++ b/src/components/views/About.tsx
@@ -104,13 +104,13 @@ const About: React.FC = () => {
               className="flex flex-col items-center justify-center gap-4 pt-4 sm:flex-row flex-wrap"
             >
               <Button size="lg" className="gap-2 px-8" asChild>
-                <Link href="/createMultiSig">
+                <Link href="/create-multisig">
                   <AddIcon className="h-4 w-4" />
                   Create a multisig
                 </Link>
               </Button>
               <Button size="lg" variant="outline" className="gap-2 px-8" asChild>
-                <Link href="/useYourMultiSig">
+                <Link href="/open-multisig">
                   <CheckCircleIcon className="h-4 w-4" />
                   Open an existing multisig
                 </Link>

--- a/src/components/views/Networks.stories.tsx
+++ b/src/components/views/Networks.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import Networks from './Networks'
+
+const meta: Meta<typeof Networks> = {
+  title: 'Views/Networks',
+  component: Networks,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof Networks> = () => <Networks />

--- a/src/components/views/Networks.tsx
+++ b/src/components/views/Networks.tsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import { AddIcon, ExternalLinkIcon } from '../icons/ChakraIcons'
+import networks from '../../constants/networks'
+import { Button } from '@/components/ui/button'
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.06, delayChildren: 0.1 }
+  }
+}
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: 'easeOut' as const }
+  }
+}
+
+const mainnets = networks.filter((chain) => !chain.testnet)
+const testnets = networks.filter((chain) => chain.testnet)
+
+const NetworkGrid: React.FC<{ chains: typeof networks }> = ({ chains }) => (
+  <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    {chains.map((chain) => (
+      <motion.div
+        key={chain.id}
+        variants={itemVariants}
+        className="flex flex-col gap-2 rounded-xl border border-border bg-muted/30 p-5"
+      >
+        <div className="flex items-baseline justify-between gap-2">
+          <h3 className="text-sm font-semibold text-foreground">{chain.name}</h3>
+          <span className="font-mono text-xs text-muted-foreground/70">#{chain.id}</span>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Native currency: <span className="font-mono text-xs">{chain.nativeCurrency.symbol}</span>
+        </p>
+        {chain.blockExplorers?.default && (
+          <a
+            href={chain.blockExplorers.default.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {chain.blockExplorers.default.name}
+            <ExternalLinkIcon boxSize={12} className="shrink-0" />
+          </a>
+        )}
+      </motion.div>
+    ))}
+  </div>
+)
+
+const Networks: React.FC = () => {
+  return (
+    <div className="flex justify-center">
+      <motion.div
+        variants={containerVariants}
+        initial="hidden"
+        animate="visible"
+        className="flex w-full max-w-[1200px] flex-col gap-8 py-4 md:gap-10 md:py-8"
+      >
+        <motion.div variants={itemVariants} className="text-center">
+          <p className="mb-3 font-mono text-xs tracking-[0.2em] text-primary">SUPPORTED NETWORKS</p>
+          <h1 className="mb-4 font-display text-3xl font-bold leading-tight tracking-tight text-foreground md:text-5xl">
+            One multisig, {mainnets.length} EVM mainnets
+          </h1>
+          <p className="mx-auto max-w-[700px] text-lg font-medium leading-relaxed text-foreground md:text-xl">
+            MyMultiSig deploys the same open-source contract on every supported network, so a wallet works the same way
+            on Ethereum as it does on Polygon, Arbitrum, or Gnosis.
+          </p>
+        </motion.div>
+
+        <motion.div variants={itemVariants} className="mx-auto max-w-[800px] text-center">
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Owners, thresholds, and signatures are enforced by the contract onchain — the list below is where that
+            contract can live today. Testnets are first-class: try the full create, sign, and execute flow with free
+            test funds before committing real assets.
+          </p>
+        </motion.div>
+
+        <motion.section variants={itemVariants} className="flex flex-col gap-4">
+          <h2 className="font-display text-xl font-semibold tracking-tight text-foreground">
+            Mainnets ({mainnets.length})
+          </h2>
+          <NetworkGrid chains={mainnets} />
+        </motion.section>
+
+        <motion.section variants={itemVariants} className="flex flex-col gap-4">
+          <h2 className="font-display text-xl font-semibold tracking-tight text-foreground">
+            Testnets ({testnets.length})
+          </h2>
+          <NetworkGrid chains={testnets} />
+        </motion.section>
+
+        <motion.div variants={itemVariants} className="flex flex-col items-center justify-center gap-4 pt-2 sm:flex-row">
+          <Button size="lg" className="gap-2 px-8" asChild>
+            <Link href="/create-multisig">
+              <AddIcon className="h-4 w-4" />
+              Create a multisig
+            </Link>
+          </Button>
+          <Button size="lg" variant="outline" className="gap-2 px-8" asChild>
+            <Link href="/docs">Read the guides</Link>
+          </Button>
+        </motion.div>
+      </motion.div>
+    </div>
+  )
+}
+
+export default Networks

--- a/src/components/views/UseYourMultiSig.tsx
+++ b/src/components/views/UseYourMultiSig.tsx
@@ -103,13 +103,13 @@ const UseYourMultiSig: React.FC = () => {
                   </div>
                   <div className="flex flex-wrap gap-3">
                     <Button asChild>
-                      <Link href="/createMultiSig" className="gap-2">
+                      <Link href="/create-multisig" className="gap-2">
                         <AddIcon className="h-4 w-4" />
                         Create a multisig
                       </Link>
                     </Button>
                     <Button variant="outline" asChild>
-                      <Link href="/importMultiSig" className="gap-2">
+                      <Link href="/import-multisig" className="gap-2">
                         <ImportIcon className="h-4 w-4" />
                         Import a multisig
                       </Link>
@@ -138,13 +138,13 @@ const UseYourMultiSig: React.FC = () => {
                 {filteredMultiSigs.length > 0 && (
                   <>
                     <Button variant="outline" asChild>
-                      <Link href="/createMultiSig" className="gap-2">
+                      <Link href="/create-multisig" className="gap-2">
                         <AddIcon className="h-4 w-4" />
                         Create a multisig
                       </Link>
                     </Button>
                     <Button variant="outline" asChild>
-                      <Link href="/importMultiSig" className="gap-2">
+                      <Link href="/import-multisig" className="gap-2">
                         <ImportIcon className="h-4 w-4" />
                         Import a multisig
                       </Link>

--- a/src/components/views/Welcome.tsx
+++ b/src/components/views/Welcome.tsx
@@ -244,6 +244,17 @@ const Welcome: React.FC = () => {
             </motion.div>
           ))}
         </div>
+        <p className="mt-8 text-sm text-muted-foreground">
+          Want more detail?{' '}
+          <Link href="/docs/what-is-a-multisig" className="text-primary underline-offset-4 hover:underline">
+            Read the full multisig guide
+          </Link>{' '}
+          or browse{' '}
+          <Link href="/docs" className="text-primary underline-offset-4 hover:underline">
+            all guides
+          </Link>
+          .
+        </p>
       </motion.section>
 
       {/* Wallet */}

--- a/src/components/views/Welcome.tsx
+++ b/src/components/views/Welcome.tsx
@@ -139,13 +139,13 @@ const Welcome: React.FC = () => {
             className="mt-8 flex flex-col gap-3 sm:flex-row"
           >
             <Button size="lg" className="gap-2 px-7" asChild>
-              <Link href="/createMultiSig">
+              <Link href="/create-multisig">
                 <AddIcon className="h-4 w-4" />
                 Create a multisig
               </Link>
             </Button>
             <Button size="lg" variant="outline" className="gap-2 px-7" asChild>
-              <Link href="/useYourMultiSig">
+              <Link href="/open-multisig">
                 <WalletIcon className="h-4 w-4" />
                 Open an existing multisig
               </Link>

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head'
 
 const titleDefault = 'MyMultiSig'
 const siteUrl = 'https://mymultisig.app'
-const descriptionDefault = 'A simple and easy MultiSig wallet for Ethereum and other EVMs networks'
+const descriptionDefault = 'A simple and easy MultiSig wallet for Ethereum and other EVM networks'
 const author = 'Marc-Aurele Besner'
 const ogImage = `${siteUrl}/images/og-image.png`
 
@@ -30,7 +30,6 @@ const Header = ({ title = titleDefault, description = descriptionDefault, path, 
       {/* Search Engine Optimization Meta Tags */}
       <title>{title}</title>
       <meta name='description' content={description} />
-      <meta name='keywords' content='nextjs,react,typescript,web3,ethereum,multisig,wallet,dapp' />
       <meta name='robots' content={noIndex ? 'noindex,nofollow' : 'index,follow'} />
       <meta name='distribution' content='web' />
       {canonicalUrl && <link rel='canonical' href={canonicalUrl} />}
@@ -63,6 +62,7 @@ const Header = ({ title = titleDefault, description = descriptionDefault, path, 
       <meta name='twitter:title' content={title} />
       <meta name='twitter:description' content={description} />
       <meta name='twitter:image' content={ogImage} />
+      <meta name='twitter:image:alt' content='MyMultiSig — open-source multisig wallet for Ethereum and EVM networks' />
     </Head>
   )
 }

--- a/src/pages.stories/create-multisig.stories.tsx
+++ b/src/pages.stories/create-multisig.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import type { StoryFn, Meta } from '@storybook/react'
 
-import Page from '../pages/useYourMultiSig'
+import Page from '../pages/create-multisig'
 import Web3Provider from '../components/web3/Web3Provider'
 
 const meta: Meta<typeof Page> = {
-  title: 'Pages/useYourMultiSig',
+  title: 'Pages/create-multisig',
   component: Page,
 }
 

--- a/src/pages.stories/open-multisig.stories.tsx
+++ b/src/pages.stories/open-multisig.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import type { StoryFn, Meta } from '@storybook/react'
 
-import Page from '../pages/createMultiSig'
+import Page from '../pages/open-multisig'
 import Web3Provider from '../components/web3/Web3Provider'
 
 const meta: Meta<typeof Page> = {
-  title: 'Pages/createMultiSig',
+  title: 'Pages/open-multisig',
   component: Page,
 }
 

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -24,7 +24,7 @@ const Error: React.FC = () => {
             <Link href='/'>Back to home</Link>
           </Button>
           <Button variant='outline' asChild>
-            <Link href='/useYourMultiSig'>Open a multisig</Link>
+            <Link href='/open-multisig'>Open a multisig</Link>
           </Button>
         </div>
       </motion.div>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -32,4 +32,13 @@ const Error: React.FC = () => {
   )
 }
 
+export async function getStaticProps() {
+  return {
+    props: {
+      title: 'Page not found — MyMultiSig',
+      noIndex: true
+    }
+  }
+}
+
 export default Error

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -30,4 +30,13 @@ const Error: React.FC = () => {
   )
 }
 
+export async function getStaticProps() {
+  return {
+    props: {
+      title: 'Something went wrong — MyMultiSig',
+      noIndex: true
+    }
+  }
+}
+
 export default Error

--- a/src/pages/create-multisig.tsx
+++ b/src/pages/create-multisig.tsx
@@ -12,7 +12,7 @@ export async function getStaticProps() {
       title: 'MyMultiSig - Create a multisig',
       description:
         'Deploy a new multisig wallet on Ethereum or any supported EVM network. Choose the owners, set the approval threshold, and create your shared wallet in minutes.',
-      path: '/createMultiSig'
+      path: '/create-multisig'
     }
   }
 }

--- a/src/pages/docs/create-a-multisig.tsx
+++ b/src/pages/docs/create-a-multisig.tsx
@@ -1,0 +1,124 @@
+import React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+
+import GuideLayout, { GuideSection, GuideText, GuideList, GuideNote, GuideSteps } from '../../components/docs/GuideLayout'
+
+const siteUrl = 'https://mymultisig.app'
+
+const steps = [
+  { name: 'Connect your wallet', text: 'Connect MetaMask, Coinbase Wallet, WalletConnect, or any injected wallet.' },
+  { name: 'Pick a network', text: 'Choose the EVM network the multisig will live on. Testnets are available for a dry run.' },
+  { name: 'Name the multisig', text: 'Give the wallet a human-readable name so co-owners can recognize it.' },
+  { name: 'Add the owners', text: 'Enter the wallet address of every owner. Each owner signs with their own wallet.' },
+  { name: 'Set the threshold', text: 'Choose how many owner approvals a transaction needs, e.g. 2 of 3.' },
+  { name: 'Deploy', text: 'Confirm the deployment transaction. The factory contract deploys your multisig onchain.' }
+]
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to create a multisig wallet',
+  description: 'Deploy a shared multisig wallet on Ethereum or any supported EVM network with MyMultiSig.',
+  url: `${siteUrl}/docs/create-a-multisig`,
+  step: steps.map((step, index) => ({
+    '@type': 'HowToStep',
+    position: index + 1,
+    name: step.name,
+    text: step.text
+  }))
+}
+
+const Page: React.FC = () => {
+  return (
+    <>
+      <Head>
+        <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+      </Head>
+      <GuideLayout
+        kicker='HOW-TO'
+        title='Create a multisig'
+        lead='Deploying a multisig with MyMultiSig takes one transaction. You choose the owners and the approval threshold; the factory contract does the rest.'
+        related={[
+          { title: 'Propose, sign, and execute transactions', href: '/docs/propose-sign-execute' },
+          { title: 'What is a multisig?', href: '/docs/what-is-a-multisig' }
+        ]}
+      >
+        <GuideSection title='Before you start'>
+          <GuideList>
+            <li>
+              A wallet (MetaMask, Coinbase Wallet, or any WalletConnect-compatible wallet) with enough native currency
+              to pay for one deployment transaction.
+            </li>
+            <li>
+              The <strong>address of every owner</strong> you want on the wallet. Double-check them — owners can only
+              be changed later through a multisig transaction that meets the threshold.
+            </li>
+            <li>
+              A decision on the <strong>threshold</strong>. Unsure? <Link href='/docs/what-is-a-multisig'>The
+              multisig guide</Link> covers the common setups; 2 of 3 is a solid default for small teams.
+            </li>
+          </GuideList>
+        </GuideSection>
+
+        <GuideSection title='Step by step'>
+          <GuideSteps>
+            <li>
+              <strong>Connect your wallet.</strong> Open <Link href='/create-multisig'>Create a multisig</Link> and
+              connect with the wallet that will pay the deployment gas.
+            </li>
+            <li>
+              <strong>Pick a network.</strong> The multisig lives on one chain — see the{' '}
+              <Link href='/networks'>supported networks</Link>. To practice first, pick a testnet like Sepolia; the
+              flow is identical and the funds are free.
+            </li>
+            <li>
+              <strong>Name the multisig.</strong> The name is a label to help you and your co-owners recognize the
+              wallet; it does not affect the contract.
+            </li>
+            <li>
+              <strong>Add the owners.</strong> Enter each owner&rsquo;s address. Every owner will approve transactions
+              by signing with their own wallet — no shared secrets.
+            </li>
+            <li>
+              <strong>Set the threshold.</strong> The number of approvals required to execute a transaction. It must
+              be at least 1 and at most the number of owners.
+            </li>
+            <li>
+              <strong>Deploy.</strong> Review the summary and confirm the transaction. The factory deploys the
+              contract, and once it confirms, the new multisig appears in{' '}
+              <Link href='/open-multisig'>your multisigs</Link>.
+            </li>
+          </GuideSteps>
+        </GuideSection>
+
+        <GuideSection title='After deployment'>
+          <GuideText>
+            Share the multisig address with your co-owners — they can{' '}
+            <Link href='/docs/import-a-multisig'>import it by address</Link> to see it on their own devices. Fund the
+            wallet by sending assets to its address like any other account, then{' '}
+            <Link href='/docs/propose-sign-execute'>propose your first transaction</Link>.
+          </GuideText>
+          <GuideNote>
+            <strong>Gas note:</strong> deploying costs a one-time fee on the network you chose. Approving later
+            transactions is free for owners — signatures are collected offchain, and only the final execution pays
+            gas.
+          </GuideNote>
+        </GuideSection>
+      </GuideLayout>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      title: 'Create a multisig - MyMultiSig Guides',
+      description:
+        'Step-by-step guide to deploying a multisig wallet on Ethereum or any supported EVM network: pick a network, add owners, set the approval threshold, and deploy.',
+      path: '/docs/create-a-multisig'
+    }
+  }
+}
+
+export default Page

--- a/src/pages/docs/import-a-multisig.tsx
+++ b/src/pages/docs/import-a-multisig.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+
+import GuideLayout, { GuideSection, GuideText, GuideList, GuideSteps } from '../../components/docs/GuideLayout'
+
+const siteUrl = 'https://mymultisig.app'
+
+const steps = [
+  { name: 'Copy the multisig address', text: 'Get the contract address of the deployed multisig you want to add.' },
+  { name: 'Pick the network', text: 'Select the chain the multisig was deployed on.' },
+  { name: 'Import by address', text: 'Paste the address; the app reads the owners, threshold, and name from the contract.' },
+  { name: 'Confirm', text: 'Review the details and add the multisig to your list.' }
+]
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to import an existing multisig',
+  description: 'Add an already-deployed MyMultiSig wallet by address to track and manage it.',
+  url: `${siteUrl}/docs/import-a-multisig`,
+  step: steps.map((step, index) => ({
+    '@type': 'HowToStep',
+    position: index + 1,
+    name: step.name,
+    text: step.text
+  }))
+}
+
+const Page: React.FC = () => {
+  return (
+    <>
+      <Head>
+        <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+      </Head>
+      <GuideLayout
+        kicker='HOW-TO'
+        title='Import an existing multisig'
+        lead='A multisig lives onchain, not in the app. If a wallet was already deployed — by a co-owner, or by you on another device — import it by address to see and manage it here.'
+        related={[
+          { title: 'Propose, sign, and execute transactions', href: '/docs/propose-sign-execute' },
+          { title: 'Create a multisig', href: '/docs/create-a-multisig' }
+        ]}
+      >
+        <GuideSection title='When to import'>
+          <GuideList>
+            <li>A co-owner created the multisig and shared its address with you.</li>
+            <li>You deployed it from another browser or device and want it on this one.</li>
+            <li>You cleared local data and the wallet no longer shows in your list.</li>
+          </GuideList>
+          <GuideText>
+            Importing never changes the contract — it only registers the address locally so the app can display it.
+            Your rights come from being an owner onchain, not from the import.
+          </GuideText>
+        </GuideSection>
+
+        <GuideSection title='Step by step'>
+          <GuideSteps>
+            <li>
+              <strong>Copy the multisig address.</strong> Any co-owner can share it; it is also visible on the block
+              explorer of the network it lives on.
+            </li>
+            <li>
+              <strong>Pick the network.</strong> On <Link href='/import-multisig'>Import a multisig</Link>, make sure
+              your wallet is connected to the chain the contract was deployed on — an address only exists on its own
+              network.
+            </li>
+            <li>
+              <strong>Paste the address.</strong> The app reads the contract onchain and shows its name, owners, and
+              threshold so you can verify it is the wallet you expect.
+            </li>
+            <li>
+              <strong>Confirm.</strong> The multisig is added to <Link href='/open-multisig'>your multisigs</Link>. If
+              your connected wallet is one of the owners, you can immediately{' '}
+              <Link href='/docs/propose-sign-execute'>propose and sign transactions</Link>.
+            </li>
+          </GuideSteps>
+        </GuideSection>
+      </GuideLayout>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      title: 'Import an existing multisig - MyMultiSig Guides',
+      description:
+        'How to add an already-deployed multisig wallet by contract address: pick the network, paste the address, verify the owners and threshold, and start signing.',
+      path: '/docs/import-a-multisig'
+    }
+  }
+}
+
+export default Page

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import { ArrowForwardIcon } from '../../components/icons/ChakraIcons'
+
+const siteUrl = 'https://mymultisig.app'
+
+export const guides = [
+  {
+    href: '/docs/what-is-a-multisig',
+    kicker: 'CONCEPTS',
+    title: 'What is a multisig?',
+    description:
+      'How multi-signature wallets work, what an approval threshold is, and when shared control beats a single key.'
+  },
+  {
+    href: '/docs/create-a-multisig',
+    kicker: 'HOW-TO',
+    title: 'Create a multisig',
+    description: 'Deploy a shared wallet: pick a network, add owners, set the threshold, and confirm the transaction.'
+  },
+  {
+    href: '/docs/propose-sign-execute',
+    kicker: 'HOW-TO',
+    title: 'Propose, sign, and execute transactions',
+    description: 'The full lifecycle of a multisig transaction, from proposal to offchain signatures to onchain execution.'
+  },
+  {
+    href: '/docs/import-a-multisig',
+    kicker: 'HOW-TO',
+    title: 'Import an existing multisig',
+    description: 'Already deployed a MyMultiSig contract? Add it by address to track and manage it from any device.'
+  }
+]
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: 'MyMultiSig guides',
+  itemListElement: guides.map((guide, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    name: guide.title,
+    url: `${siteUrl}${guide.href}`
+  }))
+}
+
+const Page: React.FC = () => {
+  return (
+    <>
+      <Head>
+        <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+      </Head>
+      <div className='flex justify-center'>
+        <div className='flex w-full max-w-[900px] flex-col gap-8 py-4 md:py-8'>
+          <div className='text-center'>
+            <p className='mb-3 font-mono text-xs tracking-[0.2em] text-primary'>DOCS</p>
+            <h1 className='mb-4 font-display text-3xl font-bold leading-tight tracking-tight text-foreground md:text-5xl'>
+              Guides
+            </h1>
+            <p className='mx-auto max-w-[640px] text-lg font-medium leading-relaxed text-foreground'>
+              Short, practical guides to multisig wallets and to running one with MyMultiSig — no prior multisig
+              experience assumed.
+            </p>
+          </div>
+
+          <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+            {guides.map((guide) => (
+              <Link
+                key={guide.href}
+                href={guide.href}
+                className='group flex flex-col gap-2 rounded-xl border border-border bg-muted/30 p-6 transition-colors hover:border-primary/40'
+              >
+                <p className='font-mono text-xs tracking-[0.2em] text-primary'>{guide.kicker}</p>
+                <h2 className='font-display text-lg font-semibold tracking-tight text-foreground'>{guide.title}</h2>
+                <p className='text-sm leading-relaxed text-muted-foreground'>{guide.description}</p>
+                <span className='mt-auto inline-flex items-center gap-1.5 pt-2 text-sm font-medium text-primary'>
+                  Read guide
+                  <ArrowForwardIcon boxSize={14} className='shrink-0 transition-transform group-hover:translate-x-0.5' />
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      title: 'MyMultiSig - Guides',
+      description:
+        'Guides to multisig wallets on EVM networks: what a multisig is, how to create one, how to propose, sign, and execute transactions, and how to import an existing wallet.',
+      path: '/docs'
+    }
+  }
+}
+
+export default Page

--- a/src/pages/docs/propose-sign-execute.tsx
+++ b/src/pages/docs/propose-sign-execute.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+
+import GuideLayout, { GuideSection, GuideText, GuideList, GuideNote, GuideSteps } from '../../components/docs/GuideLayout'
+
+const siteUrl = 'https://mymultisig.app'
+
+const steps = [
+  { name: 'Open your multisig', text: 'Select the multisig you want to transact from.' },
+  { name: 'Propose a transaction', text: 'Enter the recipient, amount, and optional contract call data.' },
+  { name: 'Collect signatures', text: 'Each owner reviews the request and signs it with their wallet — offchain and gas-free.' },
+  { name: 'Execute onchain', text: 'Once the threshold is met, any owner submits the execution transaction and the contract verifies every signature.' }
+]
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to propose, sign, and execute a multisig transaction',
+  description: 'The lifecycle of a MyMultiSig transaction: proposal, offchain EIP-712 signatures, and onchain execution.',
+  url: `${siteUrl}/docs/propose-sign-execute`,
+  step: steps.map((step, index) => ({
+    '@type': 'HowToStep',
+    position: index + 1,
+    name: step.name,
+    text: step.text
+  }))
+}
+
+const Page: React.FC = () => {
+  return (
+    <>
+      <Head>
+        <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+      </Head>
+      <GuideLayout
+        kicker='HOW-TO'
+        title='Propose, sign, and execute transactions'
+        lead='A multisig transaction has three stages: one owner proposes it, enough owners sign it, and anyone with a signature set that meets the threshold executes it onchain.'
+        related={[
+          { title: 'Create a multisig', href: '/docs/create-a-multisig' },
+          { title: 'What is a multisig?', href: '/docs/what-is-a-multisig' }
+        ]}
+      >
+        <GuideSection title='How approval works'>
+          <GuideText>
+            MyMultiSig uses <strong>EIP-712 typed signatures</strong>. When an owner approves a request, their wallet
+            shows the exact transaction details — recipient, value, data, and nonce — and signs that structured
+            message. Signing is <strong>offchain and free</strong>: no gas is spent until the final execution. The
+            contract verifies every collected signature onchain before the transaction runs, so the app never has
+            custody and can never forge an approval.
+          </GuideText>
+        </GuideSection>
+
+        <GuideSection title='Step by step'>
+          <GuideSteps>
+            <li>
+              <strong>Open your multisig.</strong> Go to <Link href='/open-multisig'>your multisigs</Link> and select
+              the wallet you want to transact from.
+            </li>
+            <li>
+              <strong>Propose a transaction.</strong> Enter the recipient and amount — or, for a contract interaction,
+              the call data. The proposal is stored as a pending request that every owner can see.
+            </li>
+            <li>
+              <strong>Collect signatures.</strong> Each owner opens the request, reviews the details, and signs with
+              their own wallet. Progress toward the threshold is visible on the request, and you can share a direct
+              link to the request with your co-owners.
+            </li>
+            <li>
+              <strong>Execute onchain.</strong> Once enough owners have signed, any owner can execute. The contract
+              checks the signatures against the owner list and threshold, then performs the transaction in a single
+              onchain call.
+            </li>
+          </GuideSteps>
+        </GuideSection>
+
+        <GuideSection title='Good to know'>
+          <GuideList>
+            <li>
+              <strong>Only the executor pays gas.</strong> Proposing and signing are free; the single execution
+              transaction carries the whole cost.
+            </li>
+            <li>
+              <strong>Requests are ordered by nonce.</strong> Each executed transaction consumes a nonce, which
+              prevents a signed request from being replayed later.
+            </li>
+            <li>
+              <strong>Signatures are per-request.</strong> An owner&rsquo;s signature covers one exact transaction —
+              changing any detail (recipient, amount, data) invalidates it.
+            </li>
+          </GuideList>
+          <GuideNote>
+            <strong>Review before you sign.</strong> Your wallet displays the full typed message. Check the recipient
+            and value against what you expect — a signature is an approval the contract will honor.
+          </GuideNote>
+        </GuideSection>
+      </GuideLayout>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      title: 'Propose, sign & execute transactions - MyMultiSig Guides',
+      description:
+        'How multisig transactions work in MyMultiSig: propose a request, collect gas-free EIP-712 signatures from owners, and execute onchain once the threshold is met.',
+      path: '/docs/propose-sign-execute'
+    }
+  }
+}
+
+export default Page

--- a/src/pages/docs/what-is-a-multisig.tsx
+++ b/src/pages/docs/what-is-a-multisig.tsx
@@ -1,0 +1,124 @@
+import React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+
+import GuideLayout, { GuideSection, GuideText, GuideList, GuideNote } from '../../components/docs/GuideLayout'
+
+const siteUrl = 'https://mymultisig.app'
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'What is a multisig wallet?',
+  description:
+    'A plain-language explanation of multi-signature wallets: how approval thresholds work, when to use one, and what MyMultiSig enforces onchain.',
+  url: `${siteUrl}/docs/what-is-a-multisig`,
+  author: { '@type': 'Person', name: 'Marc-Aurele Besner' },
+  publisher: { '@id': `${siteUrl}/#organization` }
+}
+
+const Page: React.FC = () => {
+  return (
+    <>
+      <Head>
+        <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+      </Head>
+      <GuideLayout
+        kicker='CONCEPTS'
+        title='What is a multisig?'
+        lead='A multisig (multi-signature) wallet is a shared wallet that requires multiple people to approve a transaction before it can be executed. No single person can move funds alone.'
+        related={[
+          { title: 'Create a multisig', href: '/docs/create-a-multisig' },
+          { title: 'Propose, sign, and execute transactions', href: '/docs/propose-sign-execute' }
+        ]}
+      >
+        <GuideSection title='The problem with a single key'>
+          <GuideText>
+            A regular wallet is controlled by one private key. Whoever holds that key has complete control: they can
+            send funds anywhere, at any time, with no oversight. That is fine for personal spending money, but it
+            becomes a liability the moment the wallet holds funds that belong to more than one person — a team
+            treasury, a community fund, protocol reserves. One compromised laptop, one lost seed phrase, or one bad
+            actor is all it takes.
+          </GuideText>
+        </GuideSection>
+
+        <GuideSection title='How a multisig fixes it'>
+          <GuideText>
+            A multisig is a <strong>smart contract</strong> that holds the funds instead of any individual. The
+            contract keeps a list of <strong>owners</strong> and a <strong>threshold</strong> — the number of owner
+            approvals a transaction needs before it can run. A &ldquo;2 of 3&rdquo; multisig has three owners and
+            executes only when at least two of them approve.
+          </GuideText>
+          <GuideList>
+            <li>
+              <strong>No single point of failure.</strong> One leaked key cannot drain the wallet — an attacker would
+              need to compromise enough keys to meet the threshold.
+            </li>
+            <li>
+              <strong>Built-in accountability.</strong> Every transaction is proposed, reviewed, and approved by
+              multiple people before it moves funds.
+            </li>
+            <li>
+              <strong>Enforced onchain.</strong> The rules live in the contract, not in a company policy. Nobody —
+              including the app you use to manage it — can bypass the threshold.
+            </li>
+          </GuideList>
+        </GuideSection>
+
+        <GuideSection title='Choosing a threshold'>
+          <GuideText>
+            The threshold is a trade-off between security and convenience. Higher thresholds are harder to abuse but
+            also harder to operate — if too many owners lose access, funds can be stuck. Common setups:
+          </GuideText>
+          <GuideList>
+            <li>
+              <strong>2 of 3</strong> — a solid default for small teams: one lost key does not lock the wallet, one
+              stolen key does not empty it.
+            </li>
+            <li>
+              <strong>3 of 5</strong> — common for DAOs and larger treasuries; tolerates two unavailable owners.
+            </li>
+            <li>
+              <strong>2 of 2</strong> — maximum mutual control, but a single lost key freezes the funds. Use with
+              care.
+            </li>
+          </GuideList>
+        </GuideSection>
+
+        <GuideSection title='How MyMultiSig implements it'>
+          <GuideText>
+            MyMultiSig deploys a lightweight, open-source multisig contract on{' '}
+            <Link href='/networks'>15 EVM networks</Link>. Owners approve transactions by producing{' '}
+            <strong>EIP-712 signatures</strong> — structured, human-readable messages signed with their own wallets.
+            Signatures are collected offchain (no gas to approve), and once the threshold is met, any owner submits a
+            single execution transaction. The contract verifies every signature onchain before anything moves.
+          </GuideText>
+          <GuideNote>
+            <strong>Early-stage project:</strong> the contracts are open-source and available for review, but they have
+            not been professionally audited. Use at your own risk, and try it on a testnet first.
+          </GuideNote>
+        </GuideSection>
+
+        <GuideSection title='Next steps'>
+          <GuideText>
+            Ready to try it? <Link href='/docs/create-a-multisig'>Create a multisig</Link> in a few minutes, or{' '}
+            <Link href='/docs/import-a-multisig'>import one you already deployed</Link>.
+          </GuideText>
+        </GuideSection>
+      </GuideLayout>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      title: 'What is a multisig? - MyMultiSig Guides',
+      description:
+        'A plain-language guide to multi-signature wallets: how approval thresholds work, when shared control beats a single key, and how MyMultiSig enforces it onchain.',
+      path: '/docs/what-is-a-multisig'
+    }
+  }
+}
+
+export default Page

--- a/src/pages/import-multisig.tsx
+++ b/src/pages/import-multisig.tsx
@@ -11,7 +11,7 @@ export async function getStaticProps() {
     props: {
       title: 'MyMultiSig - Import your MultiSig',
       description: 'Import an existing multisig wallet by address to track and manage it with MyMultiSig.',
-      path: '/importMultiSig'
+      path: '/import-multisig'
     }
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,12 @@ const structuredData = {
       name: 'MyMultiSig',
       url: `${siteUrl}/`,
       logo: `${siteUrl}/favicon/web-app-manifest-512x512.png`,
-      sameAs: ['https://github.com/marc-aurele-besner/mymultisig-app']
+      sameAs: [
+        'https://github.com/marc-aurele-besner/mymultisig-app',
+        'https://github.com/marc-aurele-besner/mymultisig-contract',
+        'https://www.npmjs.com/package/mymultisig-contract',
+        'https://x.com/marcaureleb'
+      ]
     },
     {
       '@type': 'WebSite',

--- a/src/pages/networks.tsx
+++ b/src/pages/networks.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import Head from 'next/head'
+
+import Networks from '../components/views/Networks'
+import networks from '../constants/networks'
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: 'EVM networks supported by MyMultiSig',
+  itemListElement: networks.map((chain, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    name: chain.name
+  }))
+}
+
+const Page: React.FC = () => {
+  return (
+    <>
+      <Head>
+        <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+      </Head>
+      <Networks />
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  const mainnetNames = networks
+    .filter((chain) => !chain.testnet)
+    .map((chain) => chain.name)
+    .join(', ')
+  return {
+    props: {
+      title: 'MyMultiSig - Supported networks',
+      description: `Deploy a multisig wallet on ${networks.length} EVM networks — ${mainnetNames} — plus their testnets. Same open-source contract everywhere.`,
+      path: '/networks'
+    }
+  }
+}
+
+export default Page

--- a/src/pages/open-multisig.tsx
+++ b/src/pages/open-multisig.tsx
@@ -12,7 +12,7 @@ export async function getStaticProps() {
       title: 'MyMultiSig - Open existing multisig',
       description:
         'Open one of your existing multisig wallets to propose, approve, and execute transactions with your co-owners.',
-      path: '/useYourMultiSig'
+      path: '/open-multisig'
     }
   }
 }

--- a/src/pages/request/[requestId].tsx
+++ b/src/pages/request/[requestId].tsx
@@ -27,7 +27,7 @@ const Page: React.FC = () => {
             <MultiSigRequestDetail address={address} multiSigRequestId={requestId} />
           </div>
           <Button asChild className="m-4">
-            <Link href="/useYourMultiSig" onClick={() => setSelectedMultiSigAddress(null)}>
+            <Link href="/open-multisig" onClick={() => setSelectedMultiSigAddress(null)}>
               Select a different MultiSig to use
             </Link>
           </Button>


### PR DESCRIPTION
Follow-up to #617. Closes the remaining technical gaps and adds the first real content surfaces.

## Technical fixes
- **404/500 now noindex** — both error pages pass `noIndex: true` via `getStaticProps`, so error responses stay out of search results.
- **Dropped the `keywords` meta tag** (ignored by engines, and it listed stack names rather than user queries).
- **Typo fix** in the default description: "EVMs networks" → "EVM networks".
- **`twitter:image:alt` added**, matching the existing `og:image:alt`.
- **Organization `sameAs` expanded** to the contract repo, npm package, and X profile.

## URL hygiene
CamelCase routes renamed to kebab-case, with permanent (308) redirects in `next.config.js` so inbound links and any indexed URLs carry over:

| Old | New |
| --- | --- |
| `/createMultiSig` | `/create-multisig` |
| `/useYourMultiSig` | `/open-multisig` |
| `/importMultiSig` | `/import-multisig` |

Internal links, canonicals, page stories, and the sitemap all point at the new paths.

## Content
- **`/networks`** — crawlable list of all 15 supported chains (derived from `src/constants/networks.ts`, so it stays in sync), grouped mainnet/testnet with chain ids, native currency, and explorer links. ItemList structured data.
- **`/docs`** hub + four guides on a shared `GuideLayout`:
  - `/docs/what-is-a-multisig` (Article schema)
  - `/docs/create-a-multisig` (HowTo schema)
  - `/docs/propose-sign-execute` (HowTo schema)
  - `/docs/import-a-multisig` (HowTo schema)
- Guides cross-link each other and the app routes; linked from the footer (Resources → Guides / Supported networks), the home FAQ, and the sitemap.

## Verification
- `yarn build` passes; all new routes prerender as SSG.
- Built HTML checked: 404/500 emit `noindex,nofollow`, keywords tag gone, `twitter:image:alt` present, canonicals correct on renamed + new pages, guide copy present in prerendered HTML.
- `routes-manifest.json` confirms the three 308 redirects.

## After deploy (manual)
- Re-check `/robots.txt`, `/sitemap.xml`, and `/images/og-image.png` serve correctly.
- Validate a page in the [Facebook sharing debugger](https://developers.facebook.com/tools/debug/) and [X card validator](https://cards-dev.twitter.com/validator).
- In Search Console: resubmit the sitemap and spot-check that old camelCase URLs report the redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)