### PR TITLE
feat: upgrade mymultisig-contract to 0.5.0 and implement the full new feature surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lucide-react": "^0.577.0",
-    "mymultisig-contract": "0.1.4",
+    "mymultisig-contract": "0.5.0",
     "next-pwa": "^5.6.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.3",

--- a/src/components/buttons/RevokeApproval.stories.tsx
+++ b/src/components/buttons/RevokeApproval.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import RevokeApproval from './RevokeApproval'
+
+const meta: Meta<typeof RevokeApproval> = {
+  title: 'Buttons/RevokeApproval',
+  component: RevokeApproval,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof RevokeApproval> = (args: React.ComponentProps<typeof RevokeApproval>) => (
+  <RevokeApproval {...args} />
+)
+Basic.args = {
+  multiSigAddress: '0x2222222222222222222222222222222222222222',
+  txHash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+}

--- a/src/components/buttons/RevokeApproval.tsx
+++ b/src/components/buttons/RevokeApproval.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+
+import useRevokeApproval from '../../hooks/useRevokeApproval'
+
+interface RevokeApprovalProps {
+  multiSigAddress: `0x${string}`
+  txHash: `0x${string}`
+  onRevoked?: () => void
+}
+
+// Withdraws the connected owner's on-chain approval of a request (0.5.0
+// wallets). The counterpart to ApproveRequest — it frees the owner's vote
+// without burning the whole nonce.
+const RevokeApproval: React.FC<RevokeApprovalProps> = ({ multiSigAddress, txHash, onRevoked }) => {
+  const { writeContract, isPending, isFinal } = useRevokeApproval(multiSigAddress, txHash)
+
+  useEffect(() => {
+    if (isFinal && onRevoked) onRevoked()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFinal])
+
+  return (
+    <Button variant='outline' className='mr-8 mt-4' onClick={() => writeContract()} disabled={isPending || isFinal}>
+      {isFinal ? 'Approval revoked' : isPending ? 'Confirm in your wallet...' : 'Revoke my approval'}
+    </Button>
+  )
+}
+
+export default RevokeApproval

--- a/src/components/forms/AdminActionForm.tsx
+++ b/src/components/forms/AdminActionForm.tsx
@@ -26,7 +26,7 @@ const AdminActionForm: React.FC<AdminActionFormProps> = ({ multiSigAddress }) =>
   const [actionId, setActionId] = useState<string>('')
   const [values, setValues] = useState<Record<string, string>>({})
 
-  const actions = adminActionsFor(walletType)
+  const actions = adminActionsFor(walletType, multiSigDetails?.version)
   const action = actions.find((a) => a.id === actionId)
 
   const details = {

--- a/src/components/forms/CreateMultiSigForm.tsx
+++ b/src/components/forms/CreateMultiSigForm.tsx
@@ -11,6 +11,7 @@ import TextInput from '../inputs/TextInput'
 import ConfirmationCard from '../cards/ConfirmationCard'
 import { MultiSigFactory, MultiSigConstructorArgs, WalletType, isExtendedWallet } from '../../models/MultiSigs'
 import useCreateMultiSig from '../../hooks/useCreateMultiSig'
+import useFactoryStats from '../../hooks/useFactoryStats'
 import { isModernFactory } from '../../utils/contractVersions'
 
 interface CreateMultiSigFormProps {
@@ -134,6 +135,9 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
   }
 
   const { data, isPending, isSuccess, writeContract } = useCreateMultiSig(constructorArgs, factory.address)
+  const { totalCount, simpleCount, extendedCount, advancedCount, supportsTypeCounts } = useFactoryStats(
+    factory.address
+  )
 
   const handleOwnerChange = (value: string, input: number) => {
     setOwners(owners.map((owner, index) => (index === input ? value : owner)))
@@ -239,6 +243,15 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
                 </span>
               </div>
             </div>
+          )}
+          {totalCount != null && totalCount > 0 && (
+            <p className='text-center text-xs text-muted-foreground'>
+              This factory has created {totalCount} wallet{totalCount === 1 ? '' : 's'}
+              {supportsTypeCounts
+                ? ` (${simpleCount ?? 0} simple, ${extendedCount ?? 0} extended, ${advancedCount ?? 0} advanced)`
+                : ''}
+              .
+            </p>
           )}
           <Button size='lg' className='w-full' onClick={() => setStep(1)}>
             Continue

--- a/src/components/forms/CreateMultiSigForm.tsx
+++ b/src/components/forms/CreateMultiSigForm.tsx
@@ -9,8 +9,9 @@ import { cn } from '@/lib/utils'
 
 import TextInput from '../inputs/TextInput'
 import ConfirmationCard from '../cards/ConfirmationCard'
-import { MultiSigFactory, MultiSigConstructorArgs, WalletType } from '../../models/MultiSigs'
+import { MultiSigFactory, MultiSigConstructorArgs, WalletType, isExtendedWallet } from '../../models/MultiSigs'
 import useCreateMultiSig from '../../hooks/useCreateMultiSig'
+import { isModernFactory } from '../../utils/contractVersions'
 
 interface CreateMultiSigFormProps {
   owner01: string
@@ -35,6 +36,15 @@ const WALLET_TYPE_FEATURES: Record<WalletType, { tagline: string; features: stri
       'Burn nonces to cancel pre-signed transactions',
       'Pin a request to a specific nonce',
       'Delegate inactive owner seats for recovery'
+    ]
+  },
+  advanced: {
+    tagline: 'Everything in Extended, tracked as an Advanced deployment.',
+    features: [
+      'Timelock on sensitive operations',
+      'Transaction guard and target allowlist',
+      'Per-owner daily spending allowances',
+      'Modules (plugins) and ERC-4337 account abstraction'
     ]
   }
 }
@@ -93,6 +103,10 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
   const [threshold, setThreshold] = useState(1)
   const [walletType, setWalletType] = useState<WalletType>('simple')
   const [isOnlyOwnerRequest, setIsOnlyOwnerRequest] = useState(false)
+  // Advanced creation (createMyMultiSigAdvanced) only exists on 0.5.0 factories.
+  const availableTypes: readonly WalletType[] = isModernFactory(factory.version)
+    ? (['simple', 'extended', 'advanced'] as const)
+    : (['simple', 'extended'] as const)
 
   const filledOwners = owners.filter((owner) => owner !== '')
   const ownersValid = filledOwners.length > 0 && filledOwners.every(isAddress)
@@ -116,7 +130,7 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
     owners: filledOwners,
     threshold,
     walletType,
-    isOnlyOwnerRequest: walletType === 'extended' ? isOnlyOwnerRequest : undefined
+    isOnlyOwnerRequest: isExtendedWallet(walletType) ? isOnlyOwnerRequest : undefined
   }
 
   const { data, isPending, isSuccess, writeContract } = useCreateMultiSig(constructorArgs, factory.address)
@@ -178,8 +192,8 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
         >
       {step === 0 && (
         <div className='flex w-full flex-col gap-4'>
-          <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
-            {(['simple', 'extended'] as const).map((type) => (
+          <div className={cn('grid grid-cols-1 gap-4', availableTypes.length > 2 ? 'md:grid-cols-3' : 'md:grid-cols-2')}>
+            {availableTypes.map((type) => (
               <button
                 key={type}
                 type='button'
@@ -215,7 +229,7 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
               </button>
             ))}
           </div>
-          {walletType === 'extended' && (
+          {isExtendedWallet(walletType) && (
             <div className='flex items-center gap-3 rounded-xl border border-border bg-muted/30 p-4'>
               <Switch checked={isOnlyOwnerRequest} onCheckedChange={setIsOnlyOwnerRequest} />
               <div className='flex flex-col'>
@@ -339,7 +353,7 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
               <span className='text-muted-foreground'>Wallet type</span>
               <span className='font-semibold capitalize text-foreground'>{walletType}</span>
             </div>
-            {walletType === 'extended' && (
+            {isExtendedWallet(walletType) && (
               <div className='flex justify-between gap-4'>
                 <span className='text-muted-foreground'>Request policy</span>
                 <span className='font-semibold text-foreground'>
@@ -388,7 +402,7 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
               disabled={writeContract == null || detailsError != null || isPending}
             >
               <AddIcon className='h-4 w-4' />
-              Deploy {walletType === 'extended' ? 'Extended ' : ''}MultiSig
+              Deploy {walletType === 'extended' ? 'Extended ' : walletType === 'advanced' ? 'Advanced ' : ''}MultiSig
             </Button>
           </div>
 

--- a/src/components/forms/CreateMultiSigRequestForm.tsx
+++ b/src/components/forms/CreateMultiSigRequestForm.tsx
@@ -6,6 +6,8 @@ import { JsonFragment } from '@ethersproject/abi'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 
+import { Switch } from '@/components/ui/switch'
+
 import TextInput from '../inputs/TextInput'
 import AddressBookInput from '../inputs/AddressBookInput'
 import SignRequest from '../buttons/SignRequest'
@@ -15,6 +17,7 @@ import useContracts from '../../states/contracts'
 import useMultiSigDetails from '../../hooks/useMultiSigDetails'
 import useWalletType from '../../hooks/useWalletType'
 import { buildRawSignatureFromFunction } from '../../utils/buildFunctionSignature'
+import { isModernWallet } from '../../utils/contractVersions'
 
 interface CreateMultiSigRequestFormProps {
   multiSigAddress: `0x${string}`
@@ -83,12 +86,19 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
   const [steps, setSteps] = useState<RequestStep[]>([{ ...EMPTY_STEP }])
   const [description, setDescription] = useState('')
   const [pinnedNonce, setPinnedNonce] = useState('')
+  const [expiry, setExpiry] = useState('')
+  const [strictBatch, setStrictBatch] = useState(false)
+  const [delegateCall, setDelegateCall] = useState(false)
   const [newContractKey, setNewContractKey] = useState(0)
   const [showNewContract, setShowNewContract] = useState(false)
   const contracts = useContracts((state) => state.contracts)
   const { address } = useAccount()
   const { walletType, allowOnlyOwnerRequest } = useWalletType(multiSigAddress)
   const { data: detailsData } = useMultiSigDetails(multiSigAddress, address ?? '0x')
+  // 0.5.0 wallets: optional signature expiry, atomic batches, and (Extended)
+  // a DELEGATECALL operation byte gated on-chain to the wallet itself.
+  const walletVersion = detailsData != null ? String(detailsData[1]) : undefined
+  const modern = isModernWallet(walletVersion)
   // Extended wallets can restrict request creation to owners; the API enforces
   // the same rule server-side.
   const isOwner = detailsData != null ? Boolean(detailsData[5]) : undefined
@@ -146,12 +156,18 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
 
   const firstInvalidIndex = steps.findIndex((s) => stepError(s) != null)
   const stepsValid = firstInvalidIndex === -1
-  const ready = stepsValid && description.trim() !== ''
+  const expiryValid = expiry === '' || new Date(expiry).getTime() > Date.now()
+  const ready = stepsValid && description.trim() !== '' && expiryValid
   const isBatch = steps.length > 1
   const totalStepGas = steps.reduce((sum, s) => (isUint(s.txnGas) ? sum + Number(s.txnGas) : sum), 0)
+  // DELEGATECALL is only accepted on-chain when the target is the wallet
+  // itself, so the toggle only applies to a single self-targeted step.
+  const delegateCallAvailable =
+    modern && walletType === 'extended' && !isBatch && steps[0].to.toLowerCase() === multiSigAddress.toLowerCase()
 
   // Sign args: a single step goes out as-is; several steps self-call
-  // multiRequest so all of them run in one multisig transaction.
+  // multiRequest (or multiRequestStrict for atomic 0.5.0 batches) so all of
+  // them run in one multisig transaction.
   let signArgs: { to: `0x${string}`; value: string; data: `0x${string}`; txnGas: string } | null = null
   let batchSteps: { to: `0x${string}`; value: string; data: `0x${string}`; txnGas: string }[] | undefined
   if (ready) {
@@ -168,7 +184,7 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
         try {
           const encoded = encodeFunctionData({
             abi: MyMultiSig as Abi,
-            functionName: 'multiRequest',
+            functionName: modern && strictBatch ? 'multiRequestStrict' : 'multiRequest',
             args: [
               steps.map((s) => s.to),
               steps.map((s) => BigInt(s.value)),
@@ -210,8 +226,9 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
       <div className='flex w-full flex-col gap-4'>
         {isBatch && (
           <p className='text-sm text-muted-foreground'>
-            All steps run in order inside one multisig transaction. A failed step is reported per-step and does not
-            revert the others.
+            {modern && strictBatch
+              ? 'All steps run in order inside one atomic multisig transaction. The first failing step reverts the whole batch.'
+              : 'All steps run in order inside one multisig transaction. A failed step is reported per-step and does not revert the others.'}
           </p>
         )}
 
@@ -408,6 +425,45 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
               />,
               'Binds the request to an exact nonce so it can be pre-signed or ordered explicitly.'
             )}
+          {modern &&
+            field(
+              'Signatures expire (optional)',
+              <TextInput
+                className='md:w-full'
+                type='datetime-local'
+                placeholder='No expiry'
+                value={expiry}
+                isInvalid={!expiryValid}
+                onChange={(e) => setExpiry(e.target.value)}
+              />,
+              expiryValid
+                ? 'The deadline is signed into every approval; the wallet refuses the request past it. Leave empty for no expiry.'
+                : 'The expiry must be in the future.'
+            )}
+          {isBatch && modern && (
+            <div className='flex items-center gap-3'>
+              <Switch checked={strictBatch} onCheckedChange={setStrictBatch} />
+              <div className='flex flex-col'>
+                <span className='text-sm font-medium text-foreground'>Atomic batch (all-or-nothing)</span>
+                <span className='text-xs text-muted-foreground'>
+                  Runs through multiRequestStrict: the first failing step reverts every step. Use it when later steps
+                  depend on earlier ones (e.g. approve then swap).
+                </span>
+              </div>
+            </div>
+          )}
+          {delegateCallAvailable && (
+            <div className='flex items-center gap-3'>
+              <Switch checked={delegateCall} onCheckedChange={setDelegateCall} />
+              <div className='flex flex-col'>
+                <span className='text-sm font-medium text-foreground'>Execute as DELEGATECALL</span>
+                <span className='text-xs text-muted-foreground'>
+                  Runs the calldata in the wallet&apos;s own storage context (operation byte 1). The wallet only
+                  accepts this for calls targeting itself. For experts — a wrong payload can corrupt the wallet.
+                </span>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className='flex flex-col items-end gap-1.5'>
@@ -419,7 +475,12 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
                 ...signArgs,
                 signatures: '',
                 ...(pinnedNonce !== '' && /^\d+$/.test(pinnedNonce) ? { txnNonce: pinnedNonce } : {}),
-                ...(batchSteps != null ? { batchSteps } : {})
+                ...(modern && expiry !== ''
+                  ? { validUntil: String(Math.floor(new Date(expiry).getTime() / 1000)) }
+                  : {}),
+                ...(delegateCallAvailable && delegateCall ? { operation: '1' } : {}),
+                ...(batchSteps != null ? { batchSteps } : {}),
+                ...(batchSteps != null && modern && strictBatch ? { strictBatch: true } : {})
               }}
             />
           ) : (

--- a/src/components/modals/DeployFactoryModal.tsx
+++ b/src/components/modals/DeployFactoryModal.tsx
@@ -13,6 +13,7 @@ import NetworkIcon from '../icons/NetworkIcon'
 import contractConstants from 'mymultisig-contract/constants'
 import useDeployFactory, { DEPLOY_STEP_LABELS } from '../../hooks/useDeployFactory'
 import deployArtifacts from '../../constants/factoryDeployArtifacts.json'
+import { LEGACY_FACTORY_DEPLOY_VERSION } from '../../constants/abi/legacy'
 import useMultiSigs from '../../states/multiSigs'
 import { persistFactory } from '../../utils/accountSync'
 import { type NetworkStatus } from '../../constants/networkStatus'
@@ -52,7 +53,7 @@ const DeployFactoryModal: React.FC<DeployFactoryModalProps> = ({ chain, status, 
           chainName: chain.name,
           address: deployedAddress,
           name: contractConstants.CONTRACT_FACTORY_NAME,
-          version: contractConstants.CONTRACT_FACTORY_VERSION,
+          version: LEGACY_FACTORY_DEPLOY_VERSION,
           multiSigCount: 0
         }
         addMultiSigFactory(factory)

--- a/src/components/multiSigDetails/AccountAbstractionPanel.stories.tsx
+++ b/src/components/multiSigDetails/AccountAbstractionPanel.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import AccountAbstractionPanel from './AccountAbstractionPanel'
+
+const meta: Meta<typeof AccountAbstractionPanel> = {
+  title: 'MultiSigDetails/AccountAbstractionPanel',
+  component: AccountAbstractionPanel,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof AccountAbstractionPanel> = (
+  args: React.ComponentProps<typeof AccountAbstractionPanel>
+) => <AccountAbstractionPanel {...args} />
+Basic.args = {
+  multiSigAddress: '0x2222222222222222222222222222222222222222',
+}

--- a/src/components/multiSigDetails/AccountAbstractionPanel.tsx
+++ b/src/components/multiSigDetails/AccountAbstractionPanel.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react'
+import { formatEther } from 'viem'
+import { Button } from '@/components/ui/button'
+
+import TextInput from '../inputs/TextInput'
+import useAdvancedFeatures from '../../hooks/useAdvancedFeatures'
+import useEntryPointDeposit from '../../hooks/useEntryPointDeposit'
+
+interface AccountAbstractionPanelProps {
+  multiSigAddress: `0x${string}`
+}
+
+const isUint = (value: string) => /^\d+$/.test(value)
+
+// ERC-4337 surface of a 0.5.0 Extended wallet: it validates UserOperations
+// against the pinned EntryPoint v0.7, so bundlers can execute owner-approved
+// transactions and pay gas from the wallet's EntryPoint deposit. This panel
+// shows the EntryPoint binding and lets anyone prefund the deposit.
+const AccountAbstractionPanel: React.FC<AccountAbstractionPanelProps> = ({ multiSigAddress }) => {
+  const { supportsAdvanced, entryPoint } = useAdvancedFeatures(multiSigAddress)
+  const { depositBalance, deposit, isPending } = useEntryPointDeposit(entryPoint, multiSigAddress)
+  const [amount, setAmount] = useState('')
+
+  if (!supportsAdvanced || entryPoint == null) return null
+
+  const ready = isUint(amount) && amount !== '' && BigInt(amount) > 0n
+
+  return (
+    <div className='flex w-full flex-col gap-3 rounded-lg border border-border p-4'>
+      <div>
+        <h3 className='text-xl font-bold text-foreground'>Account abstraction (ERC-4337)</h3>
+        <p className='text-sm text-muted-foreground'>
+          This wallet is a smart account: bundlers can submit owner-approved UserOperations through the EntryPoint, so
+          no owner needs gas in their own wallet. Gas is drawn from the wallet&apos;s EntryPoint deposit (or a
+          paymaster).
+        </p>
+      </div>
+      <div className='flex flex-col gap-1 text-sm'>
+        <span className='text-muted-foreground'>
+          EntryPoint (v0.7): <span className='break-all font-mono text-foreground'>{entryPoint}</span>
+        </span>
+        <span className='text-muted-foreground'>
+          Gas deposit:{' '}
+          <span className='font-semibold text-foreground'>
+            {depositBalance != null ? `${formatEther(depositBalance)} ETH` : '...'}
+          </span>
+        </span>
+      </div>
+      <div className='flex flex-wrap items-end gap-2'>
+        <div className='flex flex-col gap-1.5'>
+          <span className='text-sm font-semibold text-foreground'>Prefund deposit (wei)</span>
+          <TextInput
+            placeholder='e.g. 10000000000000000 (0.01 ETH)'
+            value={amount}
+            isInvalid={amount !== '' && !isUint(amount)}
+            onChange={(e) => setAmount(e.target.value.trim())}
+          />
+        </div>
+        <Button variant='outline' disabled={!ready || isPending} onClick={() => deposit(BigInt(amount))}>
+          {isPending ? 'Confirm in your wallet...' : 'Deposit'}
+        </Button>
+      </div>
+      <p className='text-xs text-muted-foreground'>
+        UserOperations bind the wallet&apos;s current nonce and the same owner-signature threshold as a direct
+        execution; the deposit only covers gas.
+      </p>
+    </div>
+  )
+}
+
+export default AccountAbstractionPanel

--- a/src/components/multiSigDetails/AdvancedFeaturesPanel.stories.tsx
+++ b/src/components/multiSigDetails/AdvancedFeaturesPanel.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import AdvancedFeaturesPanel from './AdvancedFeaturesPanel'
+
+const meta: Meta<typeof AdvancedFeaturesPanel> = {
+  title: 'MultiSigDetails/AdvancedFeaturesPanel',
+  component: AdvancedFeaturesPanel,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof AdvancedFeaturesPanel> = (
+  args: React.ComponentProps<typeof AdvancedFeaturesPanel>
+) => <AdvancedFeaturesPanel {...args} />
+Basic.args = {
+  multiSigAddress: '0x2222222222222222222222222222222222222222',
+}

--- a/src/components/multiSigDetails/AdvancedFeaturesPanel.tsx
+++ b/src/components/multiSigDetails/AdvancedFeaturesPanel.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+
+import useAdvancedFeatures, {
+  FEATURE_TIMELOCK,
+  FEATURE_GUARD,
+  FEATURE_ALLOWLIST,
+  FEATURE_ALLOWANCE,
+  FEATURE_MODULE
+} from '../../hooks/useAdvancedFeatures'
+
+interface AdvancedFeaturesPanelProps {
+  multiSigAddress: `0x${string}`
+}
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+const formatDuration = (seconds: bigint) => {
+  if (seconds >= 86400n) {
+    const days = Number(seconds / 86400n)
+    return `${days} day${days === 1 ? '' : 's'}`
+  }
+  if (seconds >= 3600n) return `${Number(seconds / 3600n)} h`
+  return `${Number(seconds)} s`
+}
+
+// Read-only overview of the 0.5.0 advanced surface (advancedFeaturesEnabled
+// bitmask + per-feature details). Renders nothing on wallets without it;
+// configuration happens through the admin actions above the panel.
+const AdvancedFeaturesPanel: React.FC<AdvancedFeaturesPanelProps> = ({ multiSigAddress }) => {
+  const {
+    supportsAdvanced,
+    featuresBitmask,
+    timelockDelay,
+    guard,
+    allowedTargetsEnabled,
+    sensitiveValueThreshold,
+    modules
+  } = useAdvancedFeatures(multiSigAddress)
+
+  if (!supportsAdvanced) return null
+
+  const features: { label: string; bit: number; detail: React.ReactNode }[] = [
+    {
+      label: 'Timelock',
+      bit: FEATURE_TIMELOCK,
+      detail:
+        timelockDelay != null && timelockDelay > 0n ? (
+          <>
+            Sensitive calls wait {formatDuration(timelockDelay)}
+            {sensitiveValueThreshold != null && sensitiveValueThreshold > 0n
+              ? `; transfers of ${sensitiveValueThreshold.toString()} wei or more count as sensitive`
+              : ''}
+            .
+          </>
+        ) : (
+          'No delay configured — every call executes immediately.'
+        )
+    },
+    {
+      label: 'Transaction guard',
+      bit: FEATURE_GUARD,
+      detail:
+        guard != null && guard.toLowerCase() !== ZERO_ADDRESS ? (
+          <span className='break-all font-mono'>{guard}</span>
+        ) : (
+          'No guard contract set.'
+        )
+    },
+    {
+      label: 'Target allowlist',
+      bit: FEATURE_ALLOWLIST,
+      detail: allowedTargetsEnabled
+        ? 'On — the wallet only calls allowed targets (including inside batches and module calls).'
+        : 'Off — it turns on with the first allowed target.'
+    },
+    {
+      label: 'Spending allowances',
+      bit: FEATURE_ALLOWANCE,
+      detail:
+        (featuresBitmask & FEATURE_ALLOWANCE) !== 0
+          ? 'At least one owner has a daily single-signer spending cap.'
+          : 'No owner has a daily spending cap.'
+    },
+    {
+      label: 'Modules',
+      bit: FEATURE_MODULE,
+      detail:
+        modules.length > 0 ? (
+          <span className='flex flex-col gap-1'>
+            {modules.map((module) => (
+              <span key={module} className='break-all font-mono'>
+                {module}
+              </span>
+            ))}
+          </span>
+        ) : (
+          'No modules enabled. Modules act for the wallet without owner signatures.'
+        )
+    }
+  ]
+
+  return (
+    <div className='flex w-full flex-col gap-4 rounded-lg border border-border p-4'>
+      <div>
+        <h3 className='text-xl font-bold text-foreground'>Advanced features</h3>
+        <p className='text-sm text-muted-foreground'>
+          Optional 0.5.0 protections, all off by default. Configure them through the administration actions above —
+          each change is itself a multisig transaction.
+        </p>
+      </div>
+      <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
+        {features.map((feature) => {
+          const enabled = (featuresBitmask & feature.bit) !== 0
+          return (
+            <div key={feature.label} className='flex flex-col gap-1 rounded-lg border border-border p-3'>
+              <div className='flex items-center justify-between gap-2'>
+                <span className='text-sm font-semibold text-foreground'>{feature.label}</span>
+                <span
+                  className={`rounded px-2 py-0.5 text-xs font-semibold ${
+                    enabled ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+                  }`}
+                >
+                  {enabled ? 'Enabled' : 'Off'}
+                </span>
+              </div>
+              <span className='text-xs text-muted-foreground'>{feature.detail}</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default AdvancedFeaturesPanel

--- a/src/components/multiSigDetails/MessageSigningPanel.stories.tsx
+++ b/src/components/multiSigDetails/MessageSigningPanel.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import MessageSigningPanel from './MessageSigningPanel'
+
+const meta: Meta<typeof MessageSigningPanel> = {
+  title: 'MultiSigDetails/MessageSigningPanel',
+  component: MessageSigningPanel,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof MessageSigningPanel> = (
+  args: React.ComponentProps<typeof MessageSigningPanel>
+) => <MessageSigningPanel {...args} />
+Basic.args = {
+  multiSigAddress: '0x2222222222222222222222222222222222222222',
+}

--- a/src/components/multiSigDetails/MessageSigningPanel.tsx
+++ b/src/components/multiSigDetails/MessageSigningPanel.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react'
+import { encodeFunctionData, toHex, type Abi } from 'viem'
+import MyMultiSig from 'mymultisig-contract/abi/MyMultiSig.json'
+
+import TextInput from '../inputs/TextInput'
+import SignRequest from '../buttons/SignRequest'
+import useMessageSigning from '../../hooks/useMessageSigning'
+
+interface MessageSigningPanelProps {
+  multiSigAddress: `0x${string}`
+}
+
+const DEFAULT_MESSAGE_GAS = '75000'
+
+const isHex = (value: string) => /^0x[a-fA-F0-9]*$/.test(value)
+
+// EIP-1271 message signing (0.5.0 wallets): the wallet can act as a signer
+// for SIWE verifiers, marketplaces or other multisigs by registering a
+// message hash on-chain. Registering/unregistering is a signMessage /
+// unsignMessage self-call, i.e. a normal multisig request; this panel checks
+// a message's status and builds those requests.
+const MessageSigningPanel: React.FC<MessageSigningPanelProps> = ({ multiSigAddress }) => {
+  const [message, setMessage] = useState('')
+
+  // Plain text is hex-encoded; a 0x string is taken as raw bytes.
+  const messageBytes: `0x${string}` | null =
+    message === '' ? null : isHex(message) ? (message as `0x${string}`) : toHex(message)
+  const { supportsMessageSigning, messageHash, isSigned } = useMessageSigning(multiSigAddress, messageBytes)
+
+  const encodedAction =
+    messageBytes != null && isSigned != null
+      ? encodeFunctionData({
+          abi: MyMultiSig as Abi,
+          functionName: isSigned ? 'unsignMessage' : 'signMessage',
+          args: [messageBytes]
+        })
+      : null
+
+  return (
+    <div className='flex w-full flex-col gap-3 rounded-lg border border-border p-4'>
+      <div>
+        <h3 className='text-xl font-bold text-foreground'>Message signing (EIP-1271)</h3>
+        <p className='text-sm text-muted-foreground'>
+          This wallet can sign messages for other applications (Sign-In with Ethereum, marketplaces, other multisigs).
+          Once the owners approve a signMessage request, any verifier calling isValidSignature accepts the message.
+        </p>
+      </div>
+      <div className='flex flex-col gap-1.5'>
+        <span className='text-sm font-semibold text-foreground'>Message</span>
+        <TextInput
+          className='md:w-full'
+          placeholder='Plain text, or 0x-prefixed bytes'
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+      </div>
+      {message !== '' && !supportsMessageSigning && (
+        <p className='text-sm text-muted-foreground'>
+          This wallet predates 0.5.0 and has no on-chain message registry.
+        </p>
+      )}
+      {supportsMessageSigning && messageHash != null && (
+        <div className='flex flex-col gap-2'>
+          <span className='break-all font-mono text-xs text-muted-foreground'>Hash: {messageHash}</span>
+          <span className={`text-sm font-semibold ${isSigned ? 'text-primary' : 'text-foreground'}`}>
+            {isSigned ? 'This message is signed by the wallet.' : 'This message is not signed.'}
+          </span>
+          {encodedAction != null && (
+            <SignRequest
+              multiSigAddress={multiSigAddress}
+              description={
+                isSigned
+                  ? `Revoke the wallet's EIP-1271 signature of: ${message.slice(0, 80)}`
+                  : `Sign message via EIP-1271: ${message.slice(0, 80)}`
+              }
+              args={{
+                to: multiSigAddress,
+                value: '0',
+                data: encodedAction,
+                txnGas: DEFAULT_MESSAGE_GAS,
+                signatures: ''
+              }}
+            />
+          )}
+          <p className='text-xs text-muted-foreground'>
+            {isSigned
+              ? 'Revoking creates a multisig request calling unsignMessage.'
+              : 'Signing creates a multisig request calling signMessage; the message counts as signed once that request executes.'}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default MessageSigningPanel

--- a/src/components/multiSigDetails/MultiSigList.stories.tsx
+++ b/src/components/multiSigDetails/MultiSigList.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import MultiSigList from './MultiSigList'
+
+const meta: Meta<typeof MultiSigList> = {
+  title: 'MultiSigDetails/MultiSigList',
+  component: MultiSigList,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof MultiSigList> = (args: React.ComponentProps<typeof MultiSigList>) => (
+  <MultiSigList {...args} />
+)
+Basic.args = {
+  multiSigAddress: '0x2222222222222222222222222222222222222222',
+  address: '0x3333333333333333333333333333333333333333',
+  multiSig: {
+    chainId: 1,
+    chainName: 'Ethereum',
+    factoryAddress: '0x1111111111111111111111111111111111111111',
+    id: 0,
+    name: 'Treasury',
+    version: '0.5.0',
+    address: '0x2222222222222222222222222222222222222222',
+    threshold: 2,
+    ownerCount: 3,
+    nonce: 4,
+    owners: [
+      '0x3333333333333333333333333333333333333333',
+      '0x4444444444444444444444444444444444444444',
+      '0x5555555555555555555555555555555555555555',
+    ],
+    isDeployed: true,
+    walletType: 'extended',
+    allowOnlyOwnerRequest: false,
+  },
+}

--- a/src/components/multiSigDetails/MultiSigList.tsx
+++ b/src/components/multiSigDetails/MultiSigList.tsx
@@ -2,18 +2,26 @@ import React from 'react'
 import Link from 'next/link'
 import { ChevronRightIcon } from 'lucide-react'
 import useMultiSigDetails from '../../hooks/useMultiSigDetails'
+import NetworkIcon from '../icons/NetworkIcon'
+import { MultiSig } from '../../models/MultiSigs'
 
 interface MultiSigListProps {
   multiSigAddress: `0x${string}`
   address: `0x${string}`
+  // Stored wallet record: supplies the network badge and the version fallback
+  // when the live reads have not answered (or the wallet is on another chain).
+  multiSig?: MultiSig
 }
 
-const MultiSigList: React.FC<MultiSigListProps> = ({ multiSigAddress, address }) => {
+const MultiSigList: React.FC<MultiSigListProps> = ({ multiSigAddress, address, multiSig }) => {
   const { data } = useMultiSigDetails(multiSigAddress, address)
 
   if (!data || !data[1]) return null
 
   const isOwner = Boolean(data[5])
+  // Prefer the wallet's live version() (it is the EIP-712 domain version);
+  // the stored record covers the brief window before the read answers.
+  const version = data[1] != null ? String(data[1]) : (multiSig?.version ?? '')
 
   return (
     <Link
@@ -26,13 +34,26 @@ const MultiSigList: React.FC<MultiSigListProps> = ({ multiSigAddress, address })
           <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] font-normal text-muted-foreground">
             {Number(data[2])} of {Number(data[3])}
           </span>
+          {version !== '' && (
+            <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] font-normal text-muted-foreground">
+              v{version}
+            </span>
+          )}
           {!isOwner && (
             <span className="shrink-0 rounded border border-border px-1.5 py-0.5 font-mono text-[11px] font-normal text-muted-foreground">
               view only
             </span>
           )}
         </span>
-        <span className="truncate font-mono text-xs text-muted-foreground">{multiSigAddress}</span>
+        <span className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+          {multiSig != null && (
+            <span className="flex shrink-0 items-center gap-1">
+              <NetworkIcon chainId={multiSig.chainId} name={multiSig.chainName} size={12} />
+              {multiSig.chainName}
+            </span>
+          )}
+          <span className="truncate font-mono">{multiSigAddress}</span>
+        </span>
       </div>
       <span className="flex shrink-0 items-center gap-1 text-sm font-medium text-muted-foreground transition-colors group-hover:text-primary">
         Open

--- a/src/components/multiSigDetails/MultiSigRequestDetail.tsx
+++ b/src/components/multiSigDetails/MultiSigRequestDetail.tsx
@@ -5,6 +5,9 @@ import { Textarea } from '@/components/ui/textarea'
 import SignRequest from '../buttons/SignRequest'
 import ExecuteRequest from '../buttons/ExecuteRequest'
 import ApproveRequest from '../buttons/ApproveRequest'
+import RevokeApproval from '../buttons/RevokeApproval'
+import ScheduledExecutionPanel from './ScheduledExecutionPanel'
+import { isModernWallet } from '../../utils/contractVersions'
 import useMultiSigRequestDetails from '../../hooks/useMultiSigRequestDetails'
 import useDeleteMultiSigRequest from '../../hooks/useDeleteMultiSigRequest'
 import useResetMultiSigRequest from '../../hooks/useResetMultiSigRequest'
@@ -28,7 +31,7 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
     requestDetails != null ? requestDetails.multiSigAddress : '0x',
     address
   )
-  const { supportsHybrid, txHash, approvedOwners, isValid, refetchApprovals } = useRequestApprovalState(
+  const { supportsHybrid, txHash, approvedOwners, isValid, walletVersion, refetchApprovals } = useRequestApprovalState(
     requestDetails != null ? requestDetails.multiSigAddress : '0x',
     requestDetails
   )
@@ -62,6 +65,13 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
   const preflightBlocked = supportsHybrid && thresholdReached && isValid === false
   const batchSteps = requestDetails.request.batchSteps
   const batchResults = requestDetails.request.batchResults
+  const modern = isModernWallet(walletVersion)
+  // 0.5.0 request metadata: signatures die past validUntil (SignatureExpired),
+  // and operation 1 runs the payload as a DELEGATECALL on the wallet itself.
+  const validUntil = requestDetails.request.validUntil
+  const hasExpiry = validUntil != null && validUntil !== '' && validUntil !== '0'
+  const isExpired = hasExpiry && Number(validUntil) * 1000 < Date.now()
+  const isDelegateCall = requestDetails.request.operation === '1'
 
   return (
     <Fragment>
@@ -97,6 +107,17 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
         {requestDetails.request.txnNonce != null &&
           requestDetails.request.txnNonce !== '' &&
           row('Pinned nonce', requestDetails.request.txnNonce)}
+        {hasExpiry &&
+          row(
+            'Signatures expire',
+            <span className={isExpired ? 'text-destructive' : undefined}>
+              {new Date(Number(validUntil) * 1000).toLocaleString()}
+              {isExpired ? ' — expired' : ''}
+            </span>
+          )}
+        {isDelegateCall && row('Operation', 'DELEGATECALL (runs in the wallet’s own storage context)')}
+        {batchSteps != null && batchSteps.length > 0 && requestDetails.request.strictBatch === true &&
+          row('Batch mode', 'Atomic — the first failing step reverts every step')}
         {row(
           'Approvals / Threshold',
           supportsHybrid
@@ -142,7 +163,14 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
           </div>
         ) : (
           <Fragment>
-            {thresholdReached && (
+            {isExpired && (
+              <div className="px-2 pt-2 text-lg font-bold text-destructive">
+                This request&apos;s signatures expired on {new Date(Number(validUntil) * 1000).toLocaleString()}. The
+                wallet refuses them (SignatureExpired). Reset the signatures and collect them again with a new
+                deadline.
+              </div>
+            )}
+            {thresholdReached && !isExpired && (
               <div className="flex flex-wrap items-center gap-2">
                 <span className="px-2 pt-2 text-xl font-bold text-foreground">
                   Execute this request
@@ -161,6 +189,14 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
                   />
                 )}
               </div>
+            )}
+            {modern && !isExpired && txHash != null && (
+              <ScheduledExecutionPanel
+                multiSigAddress={requestDetails.multiSigAddress}
+                request={requestDetails}
+                txHash={txHash}
+                thresholdReached={thresholdReached}
+              />
             )}
             <div className="flex flex-wrap items-center gap-2">
               <span className="px-2 pt-2 text-xl font-bold text-foreground">Sign this request</span>
@@ -191,6 +227,18 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
                   multiSigAddress={requestDetails.multiSigAddress}
                   txHash={txHash}
                   onApproved={() => refetchApprovals()}
+                />
+              </div>
+            )}
+            {modern && txHash != null && hasApproved && (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="px-2 pt-2 text-xl font-bold text-foreground">
+                  Withdraw your approval
+                </span>
+                <RevokeApproval
+                  multiSigAddress={requestDetails.multiSigAddress}
+                  txHash={txHash}
+                  onRevoked={() => refetchApprovals()}
                 />
               </div>
             )}

--- a/src/components/multiSigDetails/ScheduledExecutionPanel.stories.tsx
+++ b/src/components/multiSigDetails/ScheduledExecutionPanel.stories.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import ScheduledExecutionPanel from './ScheduledExecutionPanel'
+
+const meta: Meta<typeof ScheduledExecutionPanel> = {
+  title: 'MultiSigDetails/ScheduledExecutionPanel',
+  component: ScheduledExecutionPanel,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof ScheduledExecutionPanel> = (
+  args: React.ComponentProps<typeof ScheduledExecutionPanel>
+) => <ScheduledExecutionPanel {...args} />
+Basic.args = {
+  multiSigAddress: '0x2222222222222222222222222222222222222222',
+  txHash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+  thresholdReached: true,
+  request: {
+    id: 'story-request',
+    multiSigAddress: '0x2222222222222222222222222222222222222222',
+    request: {
+      to: '0x2222222222222222222222222222222222222222',
+      value: '0',
+      data: '0x7065cb480000000000000000000000003333333333333333333333333333333333333333',
+      txnGas: '75000',
+      signatures: '0x',
+    },
+    description: 'Add owner (timelocked)',
+    submitter: '0x3333333333333333333333333333333333333333',
+    signatures: [],
+    ownerSigners: [],
+    dateSubmitted: '1750000000000',
+    dateExecuted: '',
+    isActive: true,
+    isExecuted: false,
+    isCancelled: false,
+    isConfirmed: false,
+    isSuccessful: false,
+  },
+}

--- a/src/components/multiSigDetails/ScheduledExecutionPanel.tsx
+++ b/src/components/multiSigDetails/ScheduledExecutionPanel.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { Button } from '@/components/ui/button'
+
+import useScheduledTransaction, { SCHEDULE_EXECUTED_SENTINEL } from '../../hooks/useScheduledTransaction'
+import useWalletType from '../../hooks/useWalletType'
+import { MultiSigTransactionRequest } from '../../models/MultiSigs'
+
+interface ScheduledExecutionPanelProps {
+  multiSigAddress: `0x${string}`
+  request: MultiSigTransactionRequest
+  txHash: `0x${string}`
+  thresholdReached: boolean
+}
+
+// Timelock flow for 0.5.0 Extended wallets: when the wallet has a timelock
+// delay configured, sensitive calls cannot run through the direct execute
+// button — they must be scheduled with the collected signatures, wait out the
+// delay, then be executed. Renders nothing when the wallet has no timelock.
+const ScheduledExecutionPanel: React.FC<ScheduledExecutionPanelProps> = ({
+  multiSigAddress,
+  request,
+  txHash,
+  thresholdReached
+}) => {
+  const { walletType } = useWalletType(multiSigAddress)
+  const {
+    timelockEnabled,
+    timelockDelay,
+    looksSensitive,
+    readyAt,
+    ready,
+    schedule,
+    executeScheduled,
+    cancelScheduled,
+    refetchReadyAt
+  } = useScheduledTransaction(multiSigAddress, request, txHash, walletType === 'extended')
+
+  if (walletType !== 'extended' || !timelockEnabled) return null
+
+  const nowSeconds = BigInt(Math.floor(Date.now() / 1000))
+  const isScheduled = readyAt != null && readyAt > 0n
+  const isExecutedViaSchedule = readyAt != null && readyAt === SCHEDULE_EXECUTED_SENTINEL
+  const isReady = isScheduled && !isExecutedViaSchedule && readyAt <= nowSeconds
+  const formatDelay = (seconds: bigint) =>
+    seconds >= 86400n ? `${Number(seconds / 86400n)} day${seconds >= 172800n ? 's' : ''}` : `${Number(seconds)} seconds`
+
+  return (
+    <div className='mt-2 flex flex-col gap-2 rounded-lg border border-border p-3'>
+      <span className='text-xl font-bold text-foreground'>Timelock</span>
+      <p className='text-sm text-muted-foreground'>
+        This wallet enforces a {timelockDelay != null ? formatDelay(timelockDelay) : ''} timelock on sensitive calls
+        (privileged self-calls and large transfers).{' '}
+        {looksSensitive
+          ? 'This request looks sensitive: a direct execution will revert — schedule it instead.'
+          : 'If a direct execution reverts with SensitiveCallRequiresDelay, schedule it here.'}
+      </p>
+
+      {isExecutedViaSchedule ? (
+        <span className='text-sm font-semibold text-primary'>This request was executed through the timelock.</span>
+      ) : !isScheduled ? (
+        <div className='flex flex-wrap items-center gap-2'>
+          <Button
+            variant='outline'
+            disabled={!thresholdReached || !ready || schedule.isPending || schedule.isSuccess}
+            onClick={() => schedule.writeContract()}
+          >
+            {schedule.isPending ? 'Confirm in your wallet...' : 'Schedule with collected signatures'}
+          </Button>
+          {!thresholdReached && (
+            <span className='text-xs text-muted-foreground'>
+              Scheduling consumes the same {`owner signatures`} as a direct execution — reach the threshold first.
+            </span>
+          )}
+        </div>
+      ) : (
+        <div className='flex flex-wrap items-center gap-2'>
+          <span className={`text-sm font-semibold ${isReady ? 'text-primary' : 'text-foreground'}`}>
+            {isReady
+              ? 'The timelock has elapsed — this request can be executed.'
+              : `Scheduled — executable after ${new Date(Number(readyAt) * 1000).toLocaleString()}.`}
+          </span>
+          {isReady && (
+            <Button
+              disabled={executeScheduled.isPending || executeScheduled.isSuccess}
+              onClick={() => executeScheduled.writeContract()}
+            >
+              {executeScheduled.isPending ? 'Confirm in your wallet...' : 'Execute scheduled request'}
+            </Button>
+          )}
+          <Button
+            variant='destructive'
+            disabled={cancelScheduled.isPending || cancelScheduled.isSuccess}
+            onClick={() => {
+              cancelScheduled.writeContract()
+              refetchReadyAt()
+            }}
+          >
+            Cancel schedule
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ScheduledExecutionPanel

--- a/src/components/multiSigDetails/SpendingAllowancePanel.stories.tsx
+++ b/src/components/multiSigDetails/SpendingAllowancePanel.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import SpendingAllowancePanel from './SpendingAllowancePanel'
+
+const meta: Meta<typeof SpendingAllowancePanel> = {
+  title: 'MultiSigDetails/SpendingAllowancePanel',
+  component: SpendingAllowancePanel,
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof SpendingAllowancePanel> = (
+  args: React.ComponentProps<typeof SpendingAllowancePanel>
+) => <SpendingAllowancePanel {...args} />
+Basic.args = {
+  multiSigAddress: '0x2222222222222222222222222222222222222222',
+}

--- a/src/components/multiSigDetails/SpendingAllowancePanel.tsx
+++ b/src/components/multiSigDetails/SpendingAllowancePanel.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react'
+import { formatEther } from 'viem'
+import { Button } from '@/components/ui/button'
+
+import TextInput from '../inputs/TextInput'
+import AddressBookInput from '../inputs/AddressBookInput'
+import useSpendingAllowance from '../../hooks/useSpendingAllowance'
+
+interface SpendingAllowancePanelProps {
+  multiSigAddress: `0x${string}`
+}
+
+const isAddress = (value: string) => /^0x[a-fA-F0-9]{40}$/.test(value)
+const isUint = (value: string) => /^\d+$/.test(value)
+
+const DEFAULT_ALLOWANCE_GAS = '50000'
+
+// Single-signer spending against the connected owner's daily allowance
+// (0.5.0 Extended wallets). Renders only when the connected account has a
+// non-zero cap; granting caps happens through the admin actions.
+const SpendingAllowancePanel: React.FC<SpendingAllowancePanelProps> = ({ multiSigAddress }) => {
+  const { dailyLimit, remaining, spend, isPending, isSuccess, reset } = useSpendingAllowance(multiSigAddress)
+  const [to, setTo] = useState('')
+  const [amount, setAmount] = useState('')
+
+  if (dailyLimit == null || dailyLimit === 0n) return null
+
+  const ready = isAddress(to) && isUint(amount) && amount !== '' && BigInt(amount) > 0n
+  const overRemaining = ready && remaining != null && BigInt(amount) > remaining
+
+  return (
+    <div className='flex w-full flex-col gap-3 rounded-lg border border-border p-4'>
+      <div>
+        <h3 className='text-xl font-bold text-foreground'>Your daily spending allowance</h3>
+        <p className='text-sm text-muted-foreground'>
+          You can send up to {formatEther(dailyLimit)} ETH per rolling 24h window with only your own signature — no
+          other owners needed. Remaining right now:{' '}
+          <span className='font-semibold text-foreground'>
+            {remaining != null ? `${formatEther(remaining)} ETH` : '...'}
+          </span>
+          .
+        </p>
+      </div>
+      <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
+        <div className='flex flex-col gap-1.5'>
+          <span className='text-sm font-semibold text-foreground'>Send to</span>
+          <AddressBookInput placeholder='Recipient (0x...)' value={to} allowSave onChange={setTo} />
+        </div>
+        <div className='flex flex-col gap-1.5'>
+          <span className='text-sm font-semibold text-foreground'>Amount (wei)</span>
+          <TextInput
+            className='md:w-full'
+            placeholder='e.g. 100000000000000000 (0.1 ETH)'
+            value={amount}
+            isInvalid={amount !== '' && !isUint(amount)}
+            onChange={(e) => setAmount(e.target.value.trim())}
+          />
+        </div>
+      </div>
+      {overRemaining && (
+        <p className='text-sm text-destructive'>
+          That exceeds what remains of today&apos;s allowance ({remaining != null ? formatEther(remaining) : '0'} ETH).
+        </p>
+      )}
+      <div className='flex items-center gap-2'>
+        <Button
+          disabled={!ready || overRemaining || isPending || isSuccess}
+          onClick={() => spend(to as `0x${string}`, amount, DEFAULT_ALLOWANCE_GAS)}
+        >
+          {isSuccess ? 'Sent' : isPending ? 'Confirm in your wallet...' : 'Send with my allowance'}
+        </Button>
+        {isSuccess && (
+          <Button variant='outline' onClick={() => reset()}>
+            Send another
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default SpendingAllowancePanel

--- a/src/components/views/MultiSigSettings.tsx
+++ b/src/components/views/MultiSigSettings.tsx
@@ -3,6 +3,11 @@ import { useAccount, useChainId } from 'wagmi'
 
 import AdminActionForm from '../forms/AdminActionForm'
 import ExtendedGovernancePanel from '../multiSigDetails/ExtendedGovernancePanel'
+import AdvancedFeaturesPanel from '../multiSigDetails/AdvancedFeaturesPanel'
+import SpendingAllowancePanel from '../multiSigDetails/SpendingAllowancePanel'
+import MessageSigningPanel from '../multiSigDetails/MessageSigningPanel'
+import AccountAbstractionPanel from '../multiSigDetails/AccountAbstractionPanel'
+import { isModernWallet } from '../../utils/contractVersions'
 import useMultiSigDetails from '../../hooks/useMultiSigDetails'
 import useWalletType from '../../hooks/useWalletType'
 import useAdminEventSync from '../../hooks/useAdminEventSync'
@@ -70,6 +75,12 @@ const MultiSigSettings: React.FC<MultiSigSettingsProps> = ({ multiSigAddress }) 
       <AdminActionForm multiSigAddress={multiSigAddress} />
 
       {walletType === 'extended' && <ExtendedGovernancePanel multiSigAddress={multiSigAddress} owners={owners} />}
+
+      {/* 0.5.0 surface: each panel hides itself when the wallet lacks it. */}
+      {walletType === 'extended' && <AdvancedFeaturesPanel multiSigAddress={multiSigAddress} />}
+      {walletType === 'extended' && <SpendingAllowancePanel multiSigAddress={multiSigAddress} />}
+      {isModernWallet(multiSigDetails.version) && <MessageSigningPanel multiSigAddress={multiSigAddress} />}
+      {walletType === 'extended' && <AccountAbstractionPanel multiSigAddress={multiSigAddress} />}
     </div>
   )
 }

--- a/src/components/views/UseYourMultiSig.tsx
+++ b/src/components/views/UseYourMultiSig.tsx
@@ -125,7 +125,7 @@ const UseYourMultiSig: React.FC = () => {
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ duration: 0.3, delay: index * 0.05 }}
                     >
-                      <MultiSigList multiSigAddress={multiSig.address} address={address} />
+                      <MultiSigList multiSigAddress={multiSig.address} address={address} multiSig={multiSig} />
                     </motion.div>
                   ))}
                 </motion.div>

--- a/src/constants/abi/entryPoint.ts
+++ b/src/constants/abi/entryPoint.ts
@@ -1,0 +1,20 @@
+// Minimal surface of the canonical ERC-4337 EntryPoint v0.7
+// (0x0000000071727De22E5E9d8BDe0dFeC0CEB6a7d7, identical on every chain):
+// just the deposit bookkeeping the app needs to show and prefund a wallet's
+// gas balance. The full EntryPoint ABI is not shipped by mymultisig-contract.
+export const EntryPointAbi = [
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'depositTo',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function'
+  }
+] as const

--- a/src/constants/abi/legacy.ts
+++ b/src/constants/abi/legacy.ts
@@ -20,6 +20,66 @@ export const LegacyTransactionFailedEvent = [
   }
 ] as const
 
+// Removed from the package ABI in 0.5.0 (superseded by the validUntil /
+// operation flavored overloads), but still the only shapes deployed pre-0.5.0
+// wallets answer to. useRequestApprovalState appends these for legacy wallets.
+export const LegacyHashFragments = [
+  {
+    inputs: [
+      { internalType: 'address', name: 'to', type: 'address' },
+      { internalType: 'uint256', name: 'value', type: 'uint256' },
+      { internalType: 'bytes', name: 'data', type: 'bytes' },
+      { internalType: 'uint256', name: 'txnGas', type: 'uint256' },
+      { internalType: 'uint256', name: 'txnNonce', type: 'uint256' }
+    ],
+    name: 'generateHash',
+    outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'to', type: 'address' },
+      { internalType: 'uint256', name: 'value', type: 'uint256' },
+      { internalType: 'bytes', name: 'data', type: 'bytes' },
+      { internalType: 'uint256', name: 'txnGas', type: 'uint256' },
+      { internalType: 'uint256', name: 'txnNonce', type: 'uint256' },
+      { internalType: 'bytes', name: 'signatures', type: 'bytes' }
+    ],
+    name: 'isValidSignature',
+    outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function'
+  }
+] as const
+
+// Custom errors dropped from the 0.5.0 ABI but still reverted by pre-0.5.0
+// wallets; appended to write configs so decodeContractError keeps naming them.
+export const LegacyWalletErrors = [
+  { inputs: [], name: 'InvalidOwner', type: 'error' },
+  { inputs: [], name: 'OwnerAlreadySigned', type: 'error' }
+] as const
+
+// The community factory deployment ships the pre-0.5.0 bytecode snapshot in
+// factoryDeployArtifacts.json (the 0.5.0 package publishes no bytecode), whose
+// constructor takes two deployers — the 0.5.0 ABI's takes three, so deployment
+// must encode against this legacy shape.
+export const LegacyFactoryDeployAbi = [
+  {
+    inputs: [
+      { internalType: 'address', name: 'myMultiSigDeployer_', type: 'address' },
+      { internalType: 'address', name: 'myMultiSigExtendedDeployer_', type: 'address' }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor'
+  },
+  { inputs: [], name: 'initialize', outputs: [], stateMutability: 'nonpayable', type: 'function' }
+] as const
+
+// Version reported by the factory bytecode in factoryDeployArtifacts.json
+// (built from the pre-0.5.0 source commit recorded in that file).
+export const LEGACY_FACTORY_DEPLOY_VERSION = '0.1.1'
+
 // Factory 0.1.x appends `threshold` to MyMultiSigCreated, changing the topic hash.
 export const LegacyMyMultiSigCreatedEvent = [
   {

--- a/src/constants/abi/legacy.ts
+++ b/src/constants/abi/legacy.ts
@@ -80,6 +80,23 @@ export const LegacyFactoryDeployAbi = [
 // (built from the pre-0.5.0 source commit recorded in that file).
 export const LEGACY_FACTORY_DEPLOY_VERSION = '0.1.1'
 
+// Factories deployed before 0.5.0 create Extended wallets without the
+// entryPoint argument; the 0.5.0 package ABI only carries the 5-arg shape.
+export const LegacyCreateExtendedFragment = [
+  {
+    inputs: [
+      { internalType: 'string', name: 'contractName', type: 'string' },
+      { internalType: 'address[]', name: 'owners', type: 'address[]' },
+      { internalType: 'uint16', name: 'threshold', type: 'uint16' },
+      { internalType: 'bool', name: 'isOnlyOwnerRequest', type: 'bool' }
+    ],
+    name: 'createMyMultiSigExtended',
+    outputs: [{ internalType: 'address', name: 'contractAddress', type: 'address' }],
+    stateMutability: 'payable',
+    type: 'function'
+  }
+] as const
+
 // Factory 0.1.x appends `threshold` to MyMultiSigCreated, changing the topic hash.
 export const LegacyMyMultiSigCreatedEvent = [
   {

--- a/src/hooks/useAdvancedFeatures.ts
+++ b/src/hooks/useAdvancedFeatures.ts
@@ -1,0 +1,56 @@
+import { useChainId, useChains, useReadContracts } from 'wagmi'
+import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
+
+// advancedFeaturesEnabled() bitmask bits (0.5.0 Extended wallets).
+export const FEATURE_TIMELOCK = 1
+export const FEATURE_GUARD = 2
+export const FEATURE_ALLOWLIST = 4
+export const FEATURE_ALLOWANCE = 8
+export const FEATURE_MODULE = 16
+
+// Read-side of the 0.5.0 Extended advanced surface. Every call reverts on
+// pre-0.5.0 / simple wallets (allowFailure keeps the batch alive), in which
+// case supportsAdvanced stays false and consumers hide their UI.
+const useAdvancedFeatures = (multiSigAddress: `0x${string}`) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const base = {
+    chainId: chain?.id,
+    address: multiSigAddress,
+    abi: MyMultiSigExtended
+  } as const
+
+  const { data, isLoading, refetch } = useReadContracts({
+    contracts: [
+      { ...base, functionName: 'advancedFeaturesEnabled' },
+      { ...base, functionName: 'timelockDelay' },
+      { ...base, functionName: 'guard' },
+      { ...base, functionName: 'allowedTargetsEnabled' },
+      { ...base, functionName: 'sensitiveValueThreshold' },
+      { ...base, functionName: 'getModules' },
+      { ...base, functionName: 'ENTRY_POINT' }
+    ],
+    allowFailure: true,
+    query: { enabled: multiSigAddress !== '0x', retry: false }
+  })
+
+  const at = <T,>(index: number): T | undefined =>
+    data?.[index]?.status === 'success' ? (data[index].result as T) : undefined
+
+  const featuresBitmask = at<bigint>(0)
+  return {
+    supportsAdvanced: featuresBitmask != null,
+    featuresBitmask: featuresBitmask != null ? Number(featuresBitmask) : 0,
+    timelockDelay: at<bigint>(1),
+    guard: at<`0x${string}`>(2),
+    allowedTargetsEnabled: at<boolean>(3),
+    sensitiveValueThreshold: at<bigint>(4),
+    modules: (at<readonly `0x${string}`[]>(5) ?? []).map(String) as `0x${string}`[],
+    entryPoint: at<`0x${string}`>(6),
+    isLoading,
+    refetch
+  }
+}
+
+export default useAdvancedFeatures

--- a/src/hooks/useCreateMultiSig.ts
+++ b/src/hooks/useCreateMultiSig.ts
@@ -2,9 +2,11 @@ import { useEffect, useRef } from 'react'
 import { useAccount, useChainId, useChains, useWatchContractEvent } from 'wagmi'
 import MyMultiSigFactory from 'mymultisig-contract/abi/MyMultiSigFactory.json'
 import contractConstants from 'mymultisig-contract/constants'
-import { LegacyMyMultiSigCreatedEvent } from '../constants/abi/legacy'
+import { JsonFragment } from '@ethersproject/abi'
+import { LegacyMyMultiSigCreatedEvent, LegacyCreateExtendedFragment } from '../constants/abi/legacy'
 
-import { MultiSigConstructorArgs, MultiSig } from '../models/MultiSigs'
+import { MultiSigConstructorArgs, MultiSig, isExtendedWallet } from '../models/MultiSigs'
+import { isModernFactory } from '../utils/contractVersions'
 import useMultiSigs from '../states/multiSigs'
 import { useNotification } from './notifications'
 import useFinalizeTransaction from './useFinalizeTransaction'
@@ -16,20 +18,38 @@ const useCreateMultiSig = (constructorArgs: MultiSigConstructorArgs, multiSigFac
   const chains = useChains()
   const chain = chains.find((c) => c.id === chainId)
   const { address: account } = useAccount()
-  const { addMultiSig, multiSigs } = useMultiSigs()
+  const { addMultiSig, multiSigs, multiSigFactory } = useMultiSigs()
   const { notificationInfo, notificationError, notificationSuccess } = useNotification()
-  const isExtended = constructorArgs.walletType === 'extended'
+  const isExtended = isExtendedWallet(constructorArgs.walletType)
+  // 0.5.0 factories take the ERC-4337 EntryPoint on the Extended/Advanced
+  // create calls; pre-0.5.0 factories keep the 4-arg shape, which the 0.5.0
+  // package ABI no longer carries (vendored legacy fragment).
+  const factoryVersion = multiSigFactory.find(
+    (f) => f.chainId === chain?.id && f.address.toLowerCase() === multiSigFactoryAddress.toLowerCase()
+  )?.version
+  const modernFactory = isModernFactory(factoryVersion)
   const config = {
     chainId: chain?.id,
     address: multiSigFactoryAddress,
-    abi: MyMultiSigFactory,
-    functionName: (isExtended ? 'createMyMultiSigExtended' : 'createMultiSig') as string,
+    abi:
+      isExtended && !modernFactory
+        ? ([
+            ...(MyMultiSigFactory as JsonFragment[]).filter((f) => f.name !== 'createMyMultiSigExtended'),
+            ...(LegacyCreateExtendedFragment as unknown as JsonFragment[])
+          ] as JsonFragment[])
+        : (MyMultiSigFactory as JsonFragment[]),
+    functionName: (isExtended
+      ? modernFactory && constructorArgs.walletType === 'advanced'
+        ? 'createMyMultiSigAdvanced'
+        : 'createMyMultiSigExtended'
+      : 'createMultiSig') as string,
     args: isExtended
       ? ([
           constructorArgs.contractName,
           constructorArgs.owners,
           constructorArgs.threshold,
-          constructorArgs.isOnlyOwnerRequest ?? false
+          constructorArgs.isOnlyOwnerRequest ?? false,
+          ...(modernFactory ? [contractConstants.ENTRY_POINT_V07_ADDRESS] : [])
         ] as const)
       : ([constructorArgs.contractName, constructorArgs.owners, constructorArgs.threshold] as const)
   }

--- a/src/hooks/useDeployFactory.ts
+++ b/src/hooks/useDeployFactory.ts
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 import { useDeployContract, usePublicClient, useWriteContract } from 'wagmi'
 import { toast } from 'sonner'
-import MyMultiSigFactoryAbi from 'mymultisig-contract/abi/MyMultiSigFactory.json'
 import MyMultiSigDeployerAbi from 'mymultisig-contract/abi/MyMultiSigDeployer.json'
 import MyMultiSigExtendedDeployerAbi from 'mymultisig-contract/abi/MyMultiSigExtendedDeployer.json'
 
 import deployArtifacts from '../constants/factoryDeployArtifacts.json'
+import { LegacyFactoryDeployAbi } from '../constants/abi/legacy'
 
 export const DEPLOY_STEP_LABELS = [
   'Deploy MyMultiSigDeployer',
@@ -60,8 +60,10 @@ const useDeployFactory = (chainName: string) => {
       )
       setStep(3)
       toast.info(`Deploying MyMultiSigFactory on ${chainName} (3/4)…`)
+      // The shipped bytecode is the pre-0.5.0 snapshot: its constructor takes
+      // two deployers, unlike the 0.5.0 ABI's three (see LegacyFactoryDeployAbi).
       const factory = await deployOne(
-        MyMultiSigFactoryAbi,
+        LegacyFactoryDeployAbi as unknown as unknown[],
         deployArtifacts.MyMultiSigFactory.bytecode as `0x${string}`,
         [deployer, extendedDeployer]
       )
@@ -69,7 +71,7 @@ const useDeployFactory = (chainName: string) => {
       toast.info(`Initializing the factory (4/4)…`)
       const initHash = await writeContractAsync({
         address: factory,
-        abi: MyMultiSigFactoryAbi,
+        abi: LegacyFactoryDeployAbi,
         functionName: 'initialize'
       })
       setHash(initHash)

--- a/src/hooks/useEntryPointDeposit.ts
+++ b/src/hooks/useEntryPointDeposit.ts
@@ -1,0 +1,43 @@
+import { useChainId, useChains, useReadContract, useWriteContract } from 'wagmi'
+
+import { EntryPointAbi } from '../constants/abi/entryPoint'
+
+// ERC-4337 gas deposit for a 0.5.0 Extended wallet: bundlers draw the fees of
+// a UserOperation from the wallet's balance held inside the EntryPoint.
+// Anyone can prefund it via the payable depositTo(wallet).
+const useEntryPointDeposit = (entryPoint: `0x${string}` | undefined, multiSigAddress: `0x${string}`) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { data: depositBalance, refetch } = useReadContract({
+    chainId: chain?.id,
+    address: entryPoint ?? '0x',
+    abi: EntryPointAbi,
+    functionName: 'balanceOf',
+    args: [multiSigAddress],
+    query: { enabled: entryPoint != null && multiSigAddress !== '0x', retry: false }
+  })
+  const { writeContractAsync, isPending } = useWriteContract()
+
+  const deposit = async (amountWei: bigint) => {
+    if (entryPoint == null) return
+    await writeContractAsync({
+      chainId: chain?.id,
+      address: entryPoint,
+      abi: EntryPointAbi,
+      functionName: 'depositTo',
+      args: [multiSigAddress],
+      value: amountWei
+    })
+    refetch()
+  }
+
+  return {
+    depositBalance: depositBalance != null ? BigInt(depositBalance) : undefined,
+    deposit,
+    isPending,
+    refetch
+  }
+}
+
+export default useEntryPointDeposit

--- a/src/hooks/useExecTransaction.ts
+++ b/src/hooks/useExecTransaction.ts
@@ -1,15 +1,34 @@
-import { useChainId, useChains, useWatchContractEvent } from 'wagmi'
+import { useChainId, useChains, useReadContract, useWatchContractEvent } from 'wagmi'
 import MyMultiSig from 'mymultisig-contract/abi/MyMultiSig.json'
 import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
-import { LegacyTransactionFailedEvent } from '../constants/abi/legacy'
+import { JsonFragment } from '@ethersproject/abi'
+import { LegacyTransactionFailedEvent, LegacyWalletErrors } from '../constants/abi/legacy'
 
 import { MultiSigExecTransactionArgs, MultiSigTransactionRequest } from '../models/MultiSigs'
 import { useNotification, useNotificationWarning } from './notifications'
 import useFinalizeTransaction from './useFinalizeTransaction'
+import useWalletType from './useWalletType'
 import useMultiSigs from '../states/multiSigs'
 import { updateContent } from '../utils'
 import { applyAdminActionToMultiSig, decodeSelfCall } from '../utils/adminActions'
+import { isModernWallet } from '../utils/contractVersions'
+import { transactionOperation, transactionValidUntil } from '../utils/transactionTypedData'
 import persistMultiSigWalletPatch from '../utils/persistWallet'
+
+// Keeps only the execTransaction overload whose input types match exactly.
+// viem resolves overloads by name and argument count, which cannot separate
+// the 0.5.0 Extended ABI's two 7-arg overloads ((..., nonce, validUntil, sigs)
+// vs (..., validUntil, operation, sigs)) — and the first of those reverts with
+// RequiresOperationByte on 0.5.0 wallets. Legacy custom errors ride along so
+// pre-0.5.0 reverts still decode to their names.
+const withExactExecOverload = (abi: JsonFragment[], inputTypes: string): JsonFragment[] => [
+  ...abi.filter(
+    (fragment) =>
+      !(fragment.type === 'function' && fragment.name === 'execTransaction') ||
+      (fragment.inputs ?? []).map((input) => input.type).join(',') === inputTypes
+  ),
+  ...(LegacyWalletErrors as unknown as JsonFragment[])
+]
 
 const useExecTransaction = (
   args: MultiSigExecTransactionArgs,
@@ -23,25 +42,79 @@ const useExecTransaction = (
   const { notificationInfo, notificationError, notificationSuccess } = useNotification()
   const notificationEndOfLife = useNotificationWarning('Wallet approaching end of life')
   const { updateMultiSigTransactionRequest, updateMultiSig, multiSigs, multiSigTransactionRequests } = useMultiSigs()
-  // Requests built against a pinned nonce (Extended wallets only) go through the
-  // 6-arg overload; everything else uses the base 5-arg overload bound to the
-  // wallet's current nonce.
+  const { walletType, isFetched: walletTypeFetched } = useWalletType(multiSigAddress)
+  const { data: versionData } = useReadContract({
+    chainId: chain?.id,
+    address: multiSigAddress,
+    abi: MyMultiSig,
+    functionName: 'version',
+    query: { enabled: multiSigAddress !== '0x' }
+  })
+  const walletVersion = versionData != null ? String(versionData) : undefined
+  const modern = isModernWallet(walletVersion)
+  const isExtended = walletType === 'extended'
   const useExplicitNonce = args.txnNonce != null && args.txnNonce !== ''
-  const config = useExplicitNonce
-    ? {
-        chainId: chain?.id,
-        address: multiSigAddress,
-        abi: MyMultiSigExtended,
-        functionName: 'execTransaction(address,uint256,bytes,uint256,uint256,bytes)' as const,
-        args: [args.to, args.value, args.data, args.txnGas, args.txnNonce, args.signatures] as const
-      }
-    : {
-        chainId: chain?.id,
-        address: multiSigAddress,
-        abi: MyMultiSig,
-        functionName: 'execTransaction(address,uint256,bytes,uint256,bytes)' as const,
-        args: [args.to, args.value, args.data, args.txnGas, args.signatures] as const
-      }
+  const validUntil = transactionValidUntil(args)
+  const operation = transactionOperation(args)
+  // Overload per wallet generation:
+  // - 0.5.0 Extended: operation byte required (the pre-operation overloads
+  //   revert with RequiresOperationByte) — 8-arg with a pinned nonce, 7-arg
+  //   (validUntil, operation) against the current nonce otherwise.
+  // - 0.5.0 base: 6-arg with validUntil.
+  // - pre-0.5.0: the original 6-arg pinned-nonce / 5-arg overloads.
+  const config =
+    modern && isExtended && useExplicitNonce
+      ? {
+          chainId: chain?.id,
+          address: multiSigAddress,
+          abi: withExactExecOverload(
+            MyMultiSigExtended as JsonFragment[],
+            'address,uint256,bytes,uint256,uint256,uint256,uint8,bytes'
+          ),
+          functionName: 'execTransaction',
+          args: [args.to, args.value, args.data, args.txnGas, args.txnNonce, validUntil, operation, args.signatures] as const
+        }
+      : modern && isExtended
+        ? {
+            chainId: chain?.id,
+            address: multiSigAddress,
+            abi: withExactExecOverload(
+              MyMultiSigExtended as JsonFragment[],
+              'address,uint256,bytes,uint256,uint256,uint8,bytes'
+            ),
+            functionName: 'execTransaction',
+            args: [args.to, args.value, args.data, args.txnGas, validUntil, operation, args.signatures] as const
+          }
+        : modern
+          ? {
+              chainId: chain?.id,
+              address: multiSigAddress,
+              abi: withExactExecOverload(MyMultiSig as JsonFragment[], 'address,uint256,bytes,uint256,uint256,bytes'),
+              functionName: 'execTransaction',
+              args: [args.to, args.value, args.data, args.txnGas, validUntil, args.signatures] as const
+            }
+          : useExplicitNonce
+            ? {
+                chainId: chain?.id,
+                address: multiSigAddress,
+                abi: withExactExecOverload(
+                  MyMultiSigExtended as JsonFragment[],
+                  'address,uint256,bytes,uint256,uint256,bytes'
+                ),
+                functionName: 'execTransaction',
+                args: [args.to, args.value, args.data, args.txnGas, args.txnNonce, args.signatures] as const
+              }
+            : {
+                chainId: chain?.id,
+                address: multiSigAddress,
+                abi: withExactExecOverload(MyMultiSig as JsonFragment[], 'address,uint256,bytes,uint256,bytes'),
+                functionName: 'execTransaction',
+                args: [args.to, args.value, args.data, args.txnGas, args.signatures] as const
+              }
+  // The right overload is only known once the wallet's version and type have
+  // been read; block execution until then rather than sending a call the
+  // wallet would reject.
+  const overloadReady = versionData != null && (!modern || walletTypeFetched)
   const preparationError = null
   const preparationIsError = false
   const {
@@ -111,6 +184,22 @@ const useExecTransaction = (
       })
   }
 
+  // Shared success handler for TransactionExecuted / TransactionExecutedOp.
+  // Best-effort batches also emit MultiRequestExecuted, whose handler owns the
+  // status write (it carries the per-step results); writing here too could
+  // race it and drop batchResults. Strict batches revert as a whole instead
+  // of emitting MultiRequestExecuted, so reaching this event at all means
+  // every step succeeded.
+  const handleExecutedEvent = () => {
+    const steps = existingRequest.request.batchSteps
+    if (steps && steps.length > 0) {
+      if (existingRequest.request.strictBatch)
+        markExecuted(true, { batchResults: steps.map(() => ({ success: true, returnData: '0x' })) })
+      return
+    }
+    markExecuted(true)
+  }
+
   useWatchContractEvent({
     address: multiSigAddress,
     abi: MyMultiSig,
@@ -119,11 +208,21 @@ const useExecTransaction = (
       logs.forEach((log: any) => {
         const eventArgs = log.args || (log as any)
         console.log('TransactionExecuted', eventArgs.sender, eventArgs.to, eventArgs.value, eventArgs.txnNonce)
-        // Batch executions also emit MultiRequestExecuted, whose handler owns
-        // the status write (it carries the per-step results); writing here too
-        // could race it and drop batchResults.
-        if (existingRequest.request.batchSteps && existingRequest.request.batchSteps.length > 0) return
-        markExecuted(true)
+        handleExecutedEvent()
+      })
+    }
+  })
+  // 0.5.0 Extended wallets emit the operation-suffixed variants from the
+  // operation-byte execTransaction path.
+  useWatchContractEvent({
+    address: multiSigAddress,
+    abi: MyMultiSigExtended,
+    eventName: 'TransactionExecutedOp',
+    onLogs: (logs) => {
+      logs.forEach((log: any) => {
+        const eventArgs = log.args || (log as any)
+        console.log('TransactionExecutedOp', eventArgs.sender, eventArgs.to, eventArgs.value, eventArgs.txnNonce, eventArgs.operation)
+        handleExecutedEvent()
       })
     }
   })
@@ -137,6 +236,18 @@ const useExecTransaction = (
       logs.forEach((log: any) => {
         const eventArgs = log.args || (log as any)
         console.log('TxFailure', eventArgs.sender, eventArgs.to, eventArgs.value, eventArgs.txnNonce, eventArgs.reason)
+        markExecuted(false)
+      })
+    }
+  })
+  useWatchContractEvent({
+    address: multiSigAddress,
+    abi: MyMultiSigExtended,
+    eventName: 'TxFailureOp',
+    onLogs: (logs) => {
+      logs.forEach((log: any) => {
+        const eventArgs = log.args || (log as any)
+        console.log('TxFailureOp', eventArgs.sender, eventArgs.to, eventArgs.value, eventArgs.txnNonce, eventArgs.reason)
         markExecuted(false)
       })
     }
@@ -194,7 +305,9 @@ const useExecTransaction = (
     isError,
     isPending,
     isSuccess,
-    writeContract,
+    writeContract: () => {
+      if (overloadReady) writeContract()
+    },
     writeContractAsync,
     reset,
     status,

--- a/src/hooks/useFactoryStats.ts
+++ b/src/hooks/useFactoryStats.ts
@@ -1,0 +1,40 @@
+import { useChainId, useChains, useReadContracts } from 'wagmi'
+import MyMultiSigFactory from 'mymultisig-contract/abi/MyMultiSigFactory.json'
+
+// Per-type creation bookkeeping exposed by 0.5.0 factories. The typed counts
+// revert on pre-0.5.0 factories (allowFailure keeps multiSigCount usable
+// there), in which case supportsTypeCounts stays false.
+const useFactoryStats = (factoryAddress: `0x${string}`) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const base = {
+    chainId: chain?.id,
+    address: factoryAddress,
+    abi: MyMultiSigFactory
+  } as const
+
+  const { data } = useReadContracts({
+    contracts: [
+      { ...base, functionName: 'multiSigCount' },
+      { ...base, functionName: 'simpleCount' },
+      { ...base, functionName: 'extendedCount' },
+      { ...base, functionName: 'advancedCount' }
+    ],
+    allowFailure: true,
+    query: { enabled: factoryAddress !== '0x', retry: false }
+  })
+
+  const at = (index: number): number | undefined =>
+    data?.[index]?.status === 'success' ? Number(data[index].result) : undefined
+
+  return {
+    totalCount: at(0),
+    simpleCount: at(1),
+    extendedCount: at(2),
+    advancedCount: at(3),
+    supportsTypeCounts: at(1) != null
+  }
+}
+
+export default useFactoryStats

--- a/src/hooks/useMessageSigning.ts
+++ b/src/hooks/useMessageSigning.ts
@@ -1,0 +1,41 @@
+import { useChainId, useChains, useReadContract } from 'wagmi'
+import MyMultiSig from 'mymultisig-contract/abi/MyMultiSig.json'
+import { JsonFragment } from '@ethersproject/abi'
+
+// EIP-1271 message registry reads (0.5.0 wallets, base and Extended):
+// getMessageHash wraps the raw message bytes in the wallet's EIP-712 domain,
+// and isMessageSigned reports whether the owners registered that hash via a
+// signMessage self-call. Both reads revert on pre-0.5.0 wallets, in which
+// case supportsMessageSigning stays false.
+const useMessageSigning = (multiSigAddress: `0x${string}`, messageBytes: `0x${string}` | null) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const base = {
+    chainId: chain?.id,
+    address: multiSigAddress,
+    abi: MyMultiSig as JsonFragment[]
+  }
+
+  const { data: messageHash, isError: hashUnsupported } = useReadContract({
+    ...base,
+    functionName: 'getMessageHash',
+    args: [messageBytes ?? '0x'],
+    query: { enabled: multiSigAddress !== '0x' && messageBytes != null, retry: false }
+  })
+  const { data: isSigned, refetch: refetchSigned } = useReadContract({
+    ...base,
+    functionName: 'isMessageSigned',
+    args: [messageHash ?? '0x'],
+    query: { enabled: messageHash != null, retry: false }
+  })
+
+  return {
+    supportsMessageSigning: messageHash != null && !hashUnsupported,
+    messageHash: messageHash as `0x${string}` | undefined,
+    isSigned: isSigned as boolean | undefined,
+    refetchSigned
+  }
+}
+
+export default useMessageSigning

--- a/src/hooks/useRequestApprovalState.ts
+++ b/src/hooks/useRequestApprovalState.ts
@@ -1,31 +1,57 @@
 import { useChainId, useChains, useReadContract } from 'wagmi'
 import MyMultiSig from 'mymultisig-contract/abi/MyMultiSig.json'
+import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
+import { JsonFragment } from '@ethersproject/abi'
 
 import { MultiSigTransactionRequest } from '../models/MultiSigs'
+import useWalletType from './useWalletType'
+import { isModernWallet } from '../utils/contractVersions'
+import { transactionOperation, transactionValidUntil } from '../utils/transactionTypedData'
+import { LegacyHashFragments } from '../constants/abi/legacy'
 
 // Safe-style hybrid approval state for a request:
 // - the EIP-712 transaction hash (via on-chain generateHash, so domain/typehash
 //   always match the deployed wallet)
 // - owners who pre-approved that hash via approveHash
 // - an isValidSignature preflight for the collected calldata
-// On wallets older than 0.1.x these functions don't exist; every read fails and
-// the UI falls back to the pure off-chain signature flow.
+// The hash/preflight shapes moved twice: pre-0.5.0 wallets bind
+// (to, value, data, gas, nonce); 0.5.0 base wallets add validUntil; 0.5.0
+// Extended wallets add operation on top (generateHashOp / the 8-arg
+// isValidSignature). On wallets older than 0.1.x these functions don't exist;
+// every read fails and the UI falls back to the pure off-chain signature flow.
 const useRequestApprovalState = (multiSigAddress: `0x${string}`, request: MultiSigTransactionRequest | null) => {
   const chainId = useChainId()
   const chains = useChains()
   const chain = chains.find((c) => c.id === chainId)
+  // The 0.5.0 package ABI dropped the legacy 5-arg generateHash / 6-arg
+  // isValidSignature; vendored fragments keep pre-0.5.0 wallets answerable.
   const base = {
     chainId: chain?.id,
     address: multiSigAddress,
-    abi: MyMultiSig
+    abi: [...(MyMultiSig as JsonFragment[]), ...(LegacyHashFragments as unknown as JsonFragment[])]
+  }
+  const extended = {
+    chainId: chain?.id,
+    address: multiSigAddress,
+    abi: MyMultiSigExtended as JsonFragment[]
   }
   const enabled = request != null && multiSigAddress !== '0x'
+  const { walletType, isFetched: walletTypeFetched } = useWalletType(multiSigAddress)
 
   const { data: currentNonce } = useReadContract({
     ...base,
     functionName: 'nonce',
     query: { enabled }
   })
+  const { data: versionData } = useReadContract({
+    ...base,
+    functionName: 'version',
+    query: { enabled }
+  })
+  const walletVersion = versionData != null ? String(versionData) : undefined
+  const modern = isModernWallet(walletVersion)
+  const isExtended = walletType === 'extended'
+  const shapeKnown = walletVersion != null && walletTypeFetched
 
   const txnNonce =
     request?.request.txnNonce != null && request.request.txnNonce !== ''
@@ -34,7 +60,10 @@ const useRequestApprovalState = (multiSigAddress: `0x${string}`, request: MultiS
         ? BigInt(currentNonce as bigint)
         : undefined
 
-  const hashArgs =
+  const validUntil = request != null ? transactionValidUntil(request.request) : 0n
+  const operation = request != null ? transactionOperation(request.request) : 0
+
+  const commonArgs =
     request != null && txnNonce != null
       ? ([
           request.request.to,
@@ -45,11 +74,18 @@ const useRequestApprovalState = (multiSigAddress: `0x${string}`, request: MultiS
         ] as const)
       : undefined
 
+  const hashRead =
+    commonArgs == null
+      ? { ...base, functionName: 'generateHash', args: undefined }
+      : modern && isExtended
+        ? { ...extended, functionName: 'generateHashOp', args: [...commonArgs, validUntil, operation] }
+        : modern
+          ? { ...base, functionName: 'generateHash', args: [...commonArgs, validUntil] }
+          : { ...base, functionName: 'generateHash', args: commonArgs }
+
   const { data: txHash, isError: hashUnsupported } = useReadContract({
-    ...base,
-    functionName: 'generateHash',
-    args: hashArgs,
-    query: { enabled: enabled && hashArgs != null, retry: false }
+    ...hashRead,
+    query: { enabled: enabled && hashRead.args != null && shapeKnown, retry: false }
   })
 
   const { data: approvedOwners, refetch: refetchApprovals } = useReadContract({
@@ -59,21 +95,19 @@ const useRequestApprovalState = (multiSigAddress: `0x${string}`, request: MultiS
     query: { enabled: txHash != null, retry: false }
   })
 
+  const signatures = (request?.request.signatures || '0x') as `0x${string}`
+  const isValidRead =
+    commonArgs == null
+      ? { ...base, functionName: 'isValidSignature', args: undefined }
+      : modern && isExtended
+        ? { ...extended, functionName: 'isValidSignature', args: [...commonArgs, validUntil, operation, signatures] }
+        : modern
+          ? { ...base, functionName: 'isValidSignature', args: [...commonArgs, validUntil, signatures] }
+          : { ...base, functionName: 'isValidSignature', args: [...commonArgs, signatures] }
+
   const { data: isValid } = useReadContract({
-    ...base,
-    functionName: 'isValidSignature',
-    args:
-      request != null && txnNonce != null
-        ? [
-            request.request.to,
-            BigInt(request.request.value || '0'),
-            request.request.data,
-            BigInt(request.request.txnGas || '0'),
-            txnNonce,
-            (request.request.signatures || '0x') as `0x${string}`
-          ]
-        : undefined,
-    query: { enabled: enabled && txnNonce != null, retry: false }
+    ...isValidRead,
+    query: { enabled: enabled && isValidRead.args != null && shapeKnown, retry: false }
   })
 
   return {
@@ -84,6 +118,7 @@ const useRequestApprovalState = (multiSigAddress: `0x${string}`, request: MultiS
     // undefined while loading/unsupported; boolean once the wallet answered.
     isValid: isValid as boolean | undefined,
     txnNonce,
+    walletVersion,
     refetchApprovals
   }
 }

--- a/src/hooks/useRevokeApproval.ts
+++ b/src/hooks/useRevokeApproval.ts
@@ -1,0 +1,25 @@
+import { useChainId, useChains } from 'wagmi'
+import MyMultiSig from 'mymultisig-contract/abi/MyMultiSig.json'
+
+import { useNotification } from './notifications'
+import useFinalizeTransaction from './useFinalizeTransaction'
+
+// 0.5.0 wallets only: withdraws the connected owner's own on-chain approval
+// of a transaction hash without burning the nonce. Self-only — reverts with
+// NotApproved() for a hash the owner never approved.
+const useRevokeApproval = (multiSigAddress: `0x${string}`, txHash: `0x${string}` | undefined) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { notificationInfo, notificationError, notificationSuccess } = useNotification()
+  const config = {
+    chainId: chain?.id,
+    address: multiSigAddress,
+    abi: MyMultiSig,
+    functionName: 'revokeApproval' as const,
+    args: [txHash ?? '0x'] as const
+  }
+  return useFinalizeTransaction(config, notificationInfo, notificationSuccess, notificationError)
+}
+
+export default useRevokeApproval

--- a/src/hooks/useScheduledTransaction.ts
+++ b/src/hooks/useScheduledTransaction.ts
@@ -1,0 +1,143 @@
+import { useChainId, useChains, useReadContract } from 'wagmi'
+import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
+import { JsonFragment } from '@ethersproject/abi'
+
+import { MultiSigTransactionRequest } from '../models/MultiSigs'
+import { useNotification } from './notifications'
+import useFinalizeTransaction from './useFinalizeTransaction'
+import { transactionValidUntil } from '../utils/transactionTypedData'
+
+// Sentinel scheduledReadyAt writes after executeScheduled to block replays.
+export const SCHEDULE_EXECUTED_SENTINEL = 2n ** 256n - 1n
+
+// 0.5.0 Extended wallets with a timelock: sensitive calls (self-calls at a
+// registered selector, or value above the configured threshold) revert on the
+// direct execTransaction path with SensitiveCallRequiresDelay and must go
+// schedule -> wait timelockDelay -> executeScheduled instead. The schedule is
+// keyed by the transaction hash, consumes the same owner signatures as a
+// direct execution, and binds the request's validUntil across the whole
+// window. cancelScheduled needs no signatures (any owner).
+const useScheduledTransaction = (
+  multiSigAddress: `0x${string}`,
+  request: MultiSigTransactionRequest,
+  txHash: `0x${string}` | undefined,
+  enabled: boolean
+) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { notificationInfo, notificationError, notificationSuccess } = useNotification()
+  const base = {
+    chainId: chain?.id,
+    address: multiSigAddress,
+    abi: MyMultiSigExtended as JsonFragment[]
+  }
+
+  const { data: timelockDelay } = useReadContract({
+    ...base,
+    functionName: 'timelockDelay',
+    query: { enabled, retry: false }
+  })
+  const { data: currentNonce } = useReadContract({
+    ...base,
+    functionName: 'nonce',
+    query: { enabled, retry: false }
+  })
+  const {
+    data: readyAt,
+    refetch: refetchReadyAt
+  } = useReadContract({
+    ...base,
+    functionName: 'scheduledReadyAt',
+    args: [txHash ?? '0x'],
+    query: { enabled: enabled && txHash != null, retry: false }
+  })
+  // Sensitivity preview: self-calls check their selector registration; any
+  // call checks the wei threshold. Best effort — the wallet remains the
+  // authority (it reverts NotSensitive / SensitiveCallRequiresDelay).
+  const isSelfCall = request.request.to.toLowerCase() === multiSigAddress.toLowerCase()
+  const selector = request.request.data.length >= 10 ? (request.request.data.slice(0, 10) as `0x${string}`) : null
+  const { data: sensitiveSelector } = useReadContract({
+    ...base,
+    functionName: 'isSensitiveSelector',
+    args: [selector ?? '0x00000000'],
+    query: { enabled: enabled && isSelfCall && selector != null, retry: false }
+  })
+  const { data: sensitiveValueThreshold } = useReadContract({
+    ...base,
+    functionName: 'sensitiveValueThreshold',
+    query: { enabled, retry: false }
+  })
+
+  const txnNonce =
+    request.request.txnNonce != null && request.request.txnNonce !== ''
+      ? BigInt(request.request.txnNonce)
+      : currentNonce != null
+        ? BigInt(currentNonce as bigint)
+        : undefined
+  const scheduleArgs =
+    txnNonce != null
+      ? ([
+          request.request.to,
+          BigInt(request.request.value || '0'),
+          request.request.data,
+          BigInt(request.request.txnGas || '0'),
+          txnNonce,
+          transactionValidUntil(request.request)
+        ] as const)
+      : undefined
+
+  const signatures = (request.request.signatures || '0x') as `0x${string}`
+  const schedule = useFinalizeTransaction(
+    {
+      ...base,
+      functionName: 'scheduleTransaction',
+      args: [...(scheduleArgs ?? []), signatures]
+    },
+    notificationInfo,
+    notificationSuccess,
+    notificationError
+  )
+  const executeScheduled = useFinalizeTransaction(
+    {
+      ...base,
+      functionName: 'executeScheduled',
+      args: [...(scheduleArgs ?? []), signatures]
+    },
+    notificationInfo,
+    notificationSuccess,
+    notificationError
+  )
+  const cancelScheduled = useFinalizeTransaction(
+    {
+      ...base,
+      functionName: 'cancelScheduled',
+      args: scheduleArgs ?? []
+    },
+    notificationInfo,
+    notificationSuccess,
+    notificationError
+  )
+
+  const timelockEnabled = timelockDelay != null && BigInt(timelockDelay as bigint) > 0n
+  const valueSensitive =
+    sensitiveValueThreshold != null &&
+    BigInt(sensitiveValueThreshold as bigint) > 0n &&
+    BigInt(request.request.value || '0') >= BigInt(sensitiveValueThreshold as bigint)
+  const looksSensitive = (isSelfCall && Boolean(sensitiveSelector)) || valueSensitive
+
+  return {
+    // Timelock surface missing (pre-0.5.0 or simple wallet) -> stays false.
+    timelockEnabled,
+    timelockDelay: timelockDelay != null ? BigInt(timelockDelay as bigint) : undefined,
+    looksSensitive,
+    readyAt: readyAt != null ? BigInt(readyAt as bigint) : undefined,
+    ready: scheduleArgs != null,
+    schedule,
+    executeScheduled,
+    cancelScheduled,
+    refetchReadyAt
+  }
+}
+
+export default useScheduledTransaction

--- a/src/hooks/useSignedMultiSigRequest.ts
+++ b/src/hooks/useSignedMultiSigRequest.ts
@@ -4,9 +4,12 @@ import { v4 } from 'uuid'
 
 import { useNotificationSuccess, useNotificationError } from './notifications'
 import useMultiSigDetails from './useMultiSigDetails'
+import useWalletType from './useWalletType'
 import { MultiSigExecTransactionArgs, MultiSigTransactionRequest } from '../models/MultiSigs'
 import useMultiSigs from '../states/multiSigs'
 import { addContent, updateContent } from '../utils'
+import { buildTransactionTypedData } from '../utils/transactionTypedData'
+import { combineSignatures } from '../utils/signatureBlob'
 
 const useSignedMultiSigRequest = (
   multiSigAddress: `0x${string}`,
@@ -30,37 +33,8 @@ const useSignedMultiSigRequest = (
     'Successfully Signing MultiSig Request',
     'You signed the MultiSig request successfully.'
   )
-  const domain = {
-    name: multiSigDetails ? String(multiSigDetails[0]) : 'MyMultiSigFactory',
-    version: multiSigDetails ? String(multiSigDetails[1]) : '0.0.7',
-    chainId: chain?.id,
-    verifyingContract: multiSigAddress
-  } as const
-
-  const types = {
-    Transaction: [
-      {
-        name: 'to',
-        type: 'address'
-      },
-      {
-        name: 'value',
-        type: 'uint256'
-      },
-      {
-        name: 'data',
-        type: 'bytes'
-      },
-      {
-        name: 'gas',
-        type: 'uint256'
-      },
-      {
-        name: 'nonce',
-        type: 'uint96'
-      }
-    ]
-  } as const
+  const { walletType, isFetched: walletTypeFetched } = useWalletType(multiSigAddress)
+  const walletVersion = multiSigDetails ? String(multiSigDetails[1]) : undefined
 
   const isNumber = (value: string | number): boolean =>
     value != null && value !== '' && !isNaN(Number(value.toString()))
@@ -70,18 +44,27 @@ const useSignedMultiSigRequest = (
 
   const valueAndGasCheck = valueCheck && gasCheck ? true : false
 
-  const value = {
-    to: args.to,
-    value: valueCheck ? BigInt(args.value) : BigInt(0),
-    data: args.data,
-    gas: gasCheck ? BigInt(args.txnGas) : BigInt(0),
+  // The struct the wallet's typehash binds depends on its deployed version
+  // (0.5.0 adds validUntil, and operation on Extended), so signing must wait
+  // until both the on-chain details and the wallet type probe have answered.
+  const typedDataReady = multiSigDetails != null && walletTypeFetched
+  const typedData = buildTransactionTypedData({
+    domain: {
+      name: multiSigDetails ? String(multiSigDetails[0]) : 'MyMultiSigFactory',
+      version: walletVersion ?? '0.0.7',
+      chainId: chain?.id,
+      verifyingContract: multiSigAddress
+    },
+    args,
     // Requests pinned to an explicit nonce (Extended wallets) must be signed
     // against that nonce; everything else signs the wallet's current nonce.
     nonce:
       args.txnNonce != null && args.txnNonce !== ''
         ? BigInt(args.txnNonce)
-        : BigInt(multiSigDetails?.[4] != null ? String(multiSigDetails[4]) : 0)
-  } as const
+        : BigInt(multiSigDetails?.[4] != null ? String(multiSigDetails[4]) : 0),
+    walletVersion,
+    isExtended: walletType === 'extended'
+  })
 
   const { data, isError, isPending, isSuccess, error, signTypedData, reset } = useSignTypedData()
 
@@ -100,25 +83,31 @@ const useSignedMultiSigRequest = (
   useEffect(() => {
     if (isSuccess && data && chain && !dataAdded) {
       setDataAdded(true)
+      // request.signatures always holds the combined blob the wallet consumes:
+      // rebuilt from the parallel ownerSigners/signatures arrays so the
+      // version-specific encoding (flat concat pre-0.5.0, ABI-encoded
+      // (owner, sig)[] on 0.5.0) stays consistent as votes accumulate.
+      const allSigners = existingRequest
+        ? [...existingRequest.ownerSigners, address || '0x']
+        : [address || '0x']
+      const allSignatures = existingRequest ? [...existingRequest.signatures, data || '0x'] : [data || '0x']
+      const combined = combineSignatures(walletVersion, allSigners, allSignatures)
       const dataToAdd: MultiSigTransactionRequest = existingRequest
         ? {
             ...existingRequest,
             request: {
               ...existingRequest.request,
-              signatures:
-                existingRequest.request.signatures === ''
-                  ? data || '0x'
-                  : existingRequest.request.signatures + data?.substring(2)
+              signatures: combined
             },
-            signatures: [...existingRequest.signatures, data || '0x'],
-            ownerSigners: [...existingRequest.ownerSigners, address || '0x']
+            signatures: allSignatures,
+            ownerSigners: allSigners as `0x${string}`[]
           }
         : {
             id: v4(),
             multiSigAddress: multiSigAddress,
             request: {
               ...args,
-              signatures: args.signatures === '' ? data || '0x' : args.signatures + data?.substring(2)
+              signatures: combined
             },
             description,
             submitter: address || '0x',
@@ -163,7 +152,11 @@ const useSignedMultiSigRequest = (
     isSuccess,
     prepareError: !valueAndGasCheck ? null : 'Invalid value or gas',
     error,
-    signTypedData: () => signTypedData({ domain, types, primaryType: 'Transaction', message: value }),
+    // No-op until the wallet's version/type are known — signing the wrong
+    // struct shape would produce a signature the wallet rejects.
+    signTypedData: () => {
+      if (typedDataReady) signTypedData(typedData)
+    },
     reset
   }
 }

--- a/src/hooks/useSpendingAllowance.ts
+++ b/src/hooks/useSpendingAllowance.ts
@@ -1,0 +1,101 @@
+import { useState } from 'react'
+import { useAccount, useChainId, useChains, usePublicClient, useReadContract, useSignTypedData, useWriteContract } from 'wagmi'
+import { toast } from 'sonner'
+import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
+import { JsonFragment } from '@ethersproject/abi'
+
+import useMultiSigDetails from './useMultiSigDetails'
+import decodeContractError from '../utils/decodeContractError'
+import { buildTransactionTypedData } from '../utils/transactionTypedData'
+
+// Per-owner daily allowance (0.5.0 Extended wallets): a single owner with a
+// non-zero daily cap can move funds with just their own EIP-712 signature —
+// no threshold, no other owners. The wallet enforces a rolling 24h window and
+// only debits the cap when the inner call succeeds. The signature binds the
+// wallet's CURRENT nonce against the full 0.5.0 Extended typehash
+// (operation = 0), and the transaction must be sent by the signing owner
+// (the contract recovers the signer and requires it to be msg.sender).
+const useSpendingAllowance = (multiSigAddress: `0x${string}`) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { address } = useAccount()
+  const publicClient = usePublicClient()
+  const { data: details } = useMultiSigDetails(multiSigAddress, address ?? '0x')
+  const { signTypedDataAsync } = useSignTypedData()
+  const { writeContractAsync } = useWriteContract()
+  const [isPending, setIsPending] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
+
+  const base = {
+    chainId: chain?.id,
+    address: multiSigAddress,
+    abi: MyMultiSigExtended as JsonFragment[]
+  }
+  const enabled = multiSigAddress !== '0x' && address != null
+  const { data: dailyLimit, refetch: refetchLimit } = useReadContract({
+    ...base,
+    functionName: 'dailySpendingLimit',
+    args: [address ?? '0x'],
+    query: { enabled, retry: false }
+  })
+  const { data: remaining, refetch: refetchRemaining } = useReadContract({
+    ...base,
+    functionName: 'spendingLimitRemaining',
+    args: [address ?? '0x'],
+    query: { enabled, retry: false }
+  })
+
+  const spend = async (to: `0x${string}`, valueWei: string, txnGas: string) => {
+    if (!publicClient || details == null || chain == null || isPending) return
+    setIsPending(true)
+    try {
+      const typedData = buildTransactionTypedData({
+        domain: {
+          name: String(details[0]),
+          version: String(details[1]),
+          chainId: chain.id,
+          verifyingContract: multiSigAddress
+        },
+        args: { to, value: valueWei, data: '0x', txnGas, signatures: '' },
+        nonce: BigInt(String(details[4])),
+        walletVersion: String(details[1]),
+        isExtended: true
+      })
+      const signature = await signTypedDataAsync(typedData as never)
+      const hash = await writeContractAsync({
+        ...base,
+        abi: base.abi as never,
+        functionName: 'execTransactionWithSpendingAllowance',
+        args: [to, BigInt(valueWei), '0x', BigInt(txnGas), 0n, signature]
+      })
+      toast.info('Allowance transfer submitted...')
+      await publicClient.waitForTransactionReceipt({ hash, confirmations: 1, timeout: 120_000 })
+      toast.success('Allowance transfer confirmed')
+      setIsSuccess(true)
+      refetchRemaining()
+    } catch (spendError) {
+      console.error('Spending allowance error', spendError)
+      const reason = decodeContractError(spendError)
+      toast.error(reason ?? 'The allowance transfer failed.')
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return {
+    // undefined on wallets without the allowance surface (reads revert).
+    dailyLimit: dailyLimit != null ? BigInt(dailyLimit as bigint) : undefined,
+    remaining: remaining != null ? BigInt(remaining as bigint) : undefined,
+    spend,
+    isPending,
+    isSuccess,
+    reset: () => setIsSuccess(false),
+    refetch: () => {
+      refetchLimit()
+      refetchRemaining()
+    }
+  }
+}
+
+export default useSpendingAllowance

--- a/src/models/MultiSigs.ts
+++ b/src/models/MultiSigs.ts
@@ -7,7 +7,14 @@ export type MultiSigFactory = {
   multiSigCount: number
 }
 
-export type WalletType = 'simple' | 'extended'
+// 'advanced' wallets share the Extended bytecode; the distinction is factory
+// bookkeeping (createMyMultiSigAdvanced / advancedCount on 0.5.0 factories),
+// so on-chain probes report them as 'extended' and only the stored wallet
+// record remembers the creation type.
+export type WalletType = 'simple' | 'extended' | 'advanced'
+
+export const isExtendedWallet = (walletType: WalletType | undefined): boolean =>
+  walletType === 'extended' || walletType === 'advanced'
 
 export type MultiSig = {
   chainId: number
@@ -54,10 +61,19 @@ export type MultiSigExecTransactionArgs = {
   signatures: string
   // Extended wallets only: pin the request to an explicit nonce (6-arg overload)
   txnNonce?: string
+  // 0.5.0 wallets only: unix-seconds deadline bound into the EIP-712 hash;
+  // unset/'0' = no expiry. Signatures die past it (SignatureExpired).
+  validUntil?: string
+  // 0.5.0 Extended wallets only: '0' = CALL (default), '1' = DELEGATECALL
+  // (gated on-chain to to == the wallet itself). Bound into the EIP-712 hash.
+  operation?: string
   // Set when the request is a batch built through multiRequest; results are
   // filled in from the MultiRequestExecuted event after execution.
   batchSteps?: BatchStep[]
   batchResults?: BatchResult[]
+  // 0.5.0 wallets only: batch encoded as multiRequestStrict — atomic, the
+  // whole transaction reverts on the first failing step.
+  strictBatch?: boolean
 }
 
 export type MultiSigTransactionRequest = {

--- a/src/utils/adminActions.ts
+++ b/src/utils/adminActions.ts
@@ -2,6 +2,7 @@ import { encodeFunctionData, decodeFunctionData, Abi } from 'viem'
 import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
 
 import { MultiSig, WalletType } from '../models/MultiSigs'
+import { gteVersion } from './contractVersions'
 
 // Every admin operation is an onlyThis function: the multisig calls itself, so
 // these are encoded as self-call requests and go through the normal
@@ -9,7 +10,7 @@ import { MultiSig, WalletType } from '../models/MultiSigs'
 
 const abi = MyMultiSigExtended as Abi
 
-export type AdminFieldKind = 'address' | 'number' | 'boolean' | 'seconds'
+export type AdminFieldKind = 'address' | 'number' | 'boolean' | 'seconds' | 'bytes4' | 'wei'
 
 export type AdminField = {
   key: string
@@ -18,7 +19,15 @@ export type AdminField = {
   kind: AdminFieldKind
 }
 
-export type AdminActionGroup = 'owners' | 'policy' | 'nonce' | 'delegation'
+export type AdminActionGroup =
+  | 'owners'
+  | 'policy'
+  | 'nonce'
+  | 'delegation'
+  | 'timelock'
+  | 'security'
+  | 'allowance'
+  | 'modules'
 
 export const ADMIN_ACTION_GROUPS: { id: AdminActionGroup; label: string; hint: string }[] = [
   { id: 'owners', label: 'Owners', hint: 'Manage who can sign for this wallet.' },
@@ -28,7 +37,19 @@ export const ADMIN_ACTION_GROUPS: { id: AdminActionGroup; label: string; hint: s
     hint: 'Control how many signatures execute a transaction and who can propose.'
   },
   { id: 'nonce', label: 'Nonce management', hint: 'Invalidate pending or pre-signed requests.' },
-  { id: 'delegation', label: 'Inactivity delegation', hint: 'Plan owner-seat recovery if an owner goes inactive.' }
+  { id: 'delegation', label: 'Inactivity delegation', hint: 'Plan owner-seat recovery if an owner goes inactive.' },
+  { id: 'timelock', label: 'Timelock', hint: 'Delay sensitive operations behind a schedule-then-execute window.' },
+  {
+    id: 'security',
+    label: 'Guard & allowlist',
+    hint: 'Screen every transaction through a guard contract or a target allowlist.'
+  },
+  {
+    id: 'allowance',
+    label: 'Spending allowances',
+    hint: 'Let a single owner spend up to a daily cap without collecting signatures.'
+  },
+  { id: 'modules', label: 'Modules', hint: 'Plugins that can act for the wallet without owner signatures.' }
 ]
 
 export type AdminActionDefinition = {
@@ -36,6 +57,9 @@ export type AdminActionDefinition = {
   label: string
   // 'both' = exists on MyMultiSig and MyMultiSigExtended
   availableOn: 'both' | 'extended'
+  // Only offered when the deployed wallet reports at least this version
+  // (0.5.0 added the timelock/guard/allowance/module surface).
+  minWalletVersion?: string
   group: AdminActionGroup
   danger?: boolean
   hint: string
@@ -47,6 +71,8 @@ export type AdminActionDefinition = {
 
 const isAddress = (value: string) => /^0x[a-fA-F0-9]{40}$/.test(value)
 const isUint = (value: string) => /^\d+$/.test(value)
+const isBytes4 = (value: string) => /^0x[a-fA-F0-9]{8}$/.test(value)
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 export const ADMIN_ACTIONS: AdminActionDefinition[] = [
   {
@@ -186,11 +212,151 @@ export const ADMIN_ACTIONS: AdminActionDefinition[] = [
       if (v.owner.toLowerCase() === v.delegatee.toLowerCase()) return 'The delegatee must differ from the owner'
       return null
     }
+  },
+  {
+    id: 'setTimelockDelay',
+    group: 'timelock',
+    label: 'Set timelock delay',
+    availableOn: 'extended',
+    minWalletVersion: '0.5.0',
+    hint: 'Sensitive calls (privileged self-calls, transfers above the wei threshold) must then be scheduled and wait out this delay before executing. Set 0 to turn the timelock off.',
+    fields: [{ key: 'seconds', label: 'Delay (seconds)', placeholder: 'e.g. 86400 (1 day)', kind: 'seconds' }],
+    describe: (v) =>
+      v.seconds === '0' ? 'Disable the timelock' : `Set the timelock delay to ${v.seconds} seconds`,
+    buildArgs: (v) => [BigInt(v.seconds)],
+    validate: (v) => (isUint(v.seconds) ? null : 'Enter a delay in seconds')
+  },
+  {
+    id: 'setSensitiveSelector',
+    group: 'timelock',
+    label: 'Mark a selector sensitive',
+    availableOn: 'extended',
+    minWalletVersion: '0.5.0',
+    hint: 'Registers (or clears) a 4-byte function selector as sensitive when called on the wallet itself. The wallet pre-registers its own admin selectors at deployment.',
+    fields: [
+      { key: 'selector', label: 'Function selector', placeholder: 'e.g. 0x7065cb48 (addOwner)', kind: 'bytes4' },
+      { key: 'sensitive', label: 'Treat as sensitive', kind: 'boolean' }
+    ],
+    describe: (v) => `${v.sensitive === 'true' ? 'Mark' : 'Unmark'} selector ${v.selector} as sensitive`,
+    buildArgs: (v) => [v.selector, v.sensitive === 'true'],
+    validate: (v) => (isBytes4(v.selector) ? null : 'Enter a 4-byte selector like 0x7065cb48')
+  },
+  {
+    id: 'setSensitiveValueThreshold',
+    group: 'timelock',
+    label: 'Set value threshold',
+    availableOn: 'extended',
+    minWalletVersion: '0.5.0',
+    hint: 'Any transaction moving at least this many wei counts as sensitive and must go through the timelock. Set 0 to disable value-based sensitivity.',
+    fields: [{ key: 'wei', label: 'Threshold (wei)', placeholder: 'e.g. 1000000000000000000 (1 ETH)', kind: 'wei' }],
+    describe: (v) =>
+      v.wei === '0' ? 'Disable the sensitive-value threshold' : `Treat transfers of ${v.wei} wei or more as sensitive`,
+    buildArgs: (v) => [BigInt(v.wei)],
+    validate: (v) => (isUint(v.wei) ? null : 'Enter a wei amount')
+  },
+  {
+    id: 'setGuard',
+    group: 'security',
+    label: 'Set transaction guard',
+    availableOn: 'extended',
+    minWalletVersion: '0.5.0',
+    danger: true,
+    hint: 'Every transaction is pre-checked by this ITransactionGuard contract; a reverting guard blocks the wallet. Make sure the guard is audited and cannot lock you out.',
+    fields: [{ key: 'guard', label: 'Guard contract', placeholder: 'Guard address (0x...)', kind: 'address' }],
+    describe: (v) => `Set the transaction guard to ${v.guard}`,
+    buildArgs: (v) => [v.guard],
+    validate: (v) => {
+      if (!isAddress(v.guard)) return 'Enter a valid guard address'
+      if (v.guard.toLowerCase() === ZERO_ADDRESS) return 'The wallet rejects the zero address as a guard'
+      return null
+    }
+  },
+  {
+    id: 'setAllowedTarget',
+    group: 'security',
+    label: 'Allow / disallow a target',
+    availableOn: 'extended',
+    minWalletVersion: '0.5.0',
+    hint: 'The built-in allowlist turns on with the first allowed target: from then on the wallet only calls allowed addresses. It also applies inside batches and module calls.',
+    fields: [
+      { key: 'target', label: 'Target', placeholder: 'Target address (0x...)', kind: 'address' },
+      { key: 'allowed', label: 'Allowed', kind: 'boolean' }
+    ],
+    describe: (v) => `${v.allowed === 'true' ? 'Allow' : 'Disallow'} calls to ${v.target}`,
+    buildArgs: (v) => [v.target, v.allowed === 'true'],
+    validate: (v) => (isAddress(v.target) ? null : 'Enter a valid target address')
+  },
+  {
+    id: 'setDailySpendingLimit',
+    group: 'allowance',
+    label: 'Set a daily spending limit',
+    availableOn: 'extended',
+    minWalletVersion: '0.5.0',
+    hint: 'Lets this owner spend up to the cap per rolling 24h window with just their own signature (no threshold). Set 0 to remove the allowance.',
+    fields: [
+      { key: 'owner', label: 'Owner', placeholder: 'Owner address (0x...)', kind: 'address' },
+      { key: 'wei', label: 'Daily cap (wei)', placeholder: 'e.g. 1000000000000000000 (1 ETH)', kind: 'wei' }
+    ],
+    describe: (v) =>
+      v.wei === '0'
+        ? `Remove the daily spending allowance of ${v.owner}`
+        : `Allow ${v.owner} to spend up to ${v.wei} wei per day single-signed`,
+    buildArgs: (v) => [v.owner, BigInt(v.wei)],
+    validate: (v) => {
+      if (!isAddress(v.owner)) return 'Enter a valid owner address'
+      if (!isUint(v.wei)) return 'Enter a wei amount'
+      return null
+    }
+  },
+  {
+    id: 'enableModule',
+    group: 'modules',
+    label: 'Enable a module',
+    availableOn: 'extended',
+    minWalletVersion: '0.5.0',
+    danger: true,
+    hint: 'Modules execute transactions for the wallet WITHOUT owner signatures. Only enable contracts you fully trust — a malicious module can drain the wallet.',
+    fields: [{ key: 'module', label: 'Module', placeholder: 'Module address (0x...)', kind: 'address' }],
+    describe: (v) => `Enable module ${v.module} (bypasses the signature threshold)`,
+    buildArgs: (v) => [v.module],
+    validate: (v) => {
+      if (!isAddress(v.module)) return 'Enter a valid module address'
+      if (v.module.toLowerCase() === ZERO_ADDRESS) return 'The wallet rejects the zero address as a module'
+      return null
+    }
+  },
+  {
+    id: 'disableModule',
+    group: 'modules',
+    label: 'Disable a module',
+    availableOn: 'extended',
+    minWalletVersion: '0.5.0',
+    hint: 'Modules form a linked list: pass the module that comes right before the one you remove in the module list, or the zero address when removing the first one.',
+    fields: [
+      {
+        key: 'prev',
+        label: 'Previous module',
+        placeholder: '0x000...000 when removing the first module',
+        kind: 'address'
+      },
+      { key: 'module', label: 'Module to disable', placeholder: 'Module address (0x...)', kind: 'address' }
+    ],
+    describe: (v) => `Disable module ${v.module}`,
+    buildArgs: (v) => [v.prev, v.module],
+    validate: (v) => {
+      if (!isAddress(v.prev) || !isAddress(v.module)) return 'Enter valid module addresses'
+      if (v.prev.toLowerCase() === v.module.toLowerCase()) return 'The previous module must differ from the module'
+      return null
+    }
   }
 ]
 
-export const adminActionsFor = (walletType: WalletType | undefined) =>
-  ADMIN_ACTIONS.filter((a) => a.availableOn === 'both' || walletType === 'extended')
+export const adminActionsFor = (walletType: WalletType | undefined, walletVersion?: string) =>
+  ADMIN_ACTIONS.filter(
+    (a) =>
+      (a.availableOn === 'both' || walletType === 'extended') &&
+      (a.minWalletVersion == null || gteVersion(walletVersion, a.minWalletVersion))
+  )
 
 export const encodeAdminAction = (action: AdminActionDefinition, values: Record<string, string>): `0x${string}` =>
   encodeFunctionData({ abi, functionName: action.id, args: action.buildArgs(values) })

--- a/src/utils/contractVersions.ts
+++ b/src/utils/contractVersions.ts
@@ -1,0 +1,32 @@
+// Deployed wallets are frozen at the contract version they were built from
+// (version() returns '0.0.4' ... '0.1.3' for pre-0.5.0 deployments, '0.5.0'
+// after), so every protocol surface that changed in 0.5.0 — EIP-712 typehash,
+// signature blob encoding, execTransaction overloads — must branch on the
+// wallet's reported version rather than the npm package's.
+
+const parseVersion = (version: string): number[] =>
+  version
+    .trim()
+    .split('.')
+    .map((part) => Number(part.replace(/[^0-9].*$/, '')) || 0)
+
+export const gteVersion = (version: string | undefined, target: string): boolean => {
+  if (version == null || version === '') return false
+  const a = parseVersion(version)
+  const b = parseVersion(target)
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0)
+    if (diff !== 0) return diff > 0
+  }
+  return true
+}
+
+// 0.5.0 wallets: validUntil + operation in the typehash, tuple-encoded
+// signature blobs, timelock/guard/allowance/module surface, ERC-4337.
+// No 0.2.x–0.4.x wallets were ever deployed (the package jumped 0.1.4→0.5.0),
+// so a single cutoff covers every breaking change in between.
+export const isModernWallet = (version: string | undefined): boolean => gteVersion(version, '0.5.0')
+
+// 0.5.0 factories take an entryPoint on createMyMultiSigExtended and expose
+// createMyMultiSigAdvanced + per-type bookkeeping.
+export const isModernFactory = (version: string | undefined): boolean => gteVersion(version, '0.5.0')

--- a/src/utils/decodeContractError.ts
+++ b/src/utils/decodeContractError.ts
@@ -24,7 +24,40 @@ const ERROR_MESSAGES: Record<string, string> = {
   DelegateeCannotBeZero: 'The delegatee cannot be the zero address.',
   DelegateeAlreadyOwnerOrDelegatee: 'The delegatee is already an owner or a delegatee.',
   SenderNotDelegatee: 'Only the named delegatee can take over this seat.',
-  OwnerStillActive: 'The owner is still active; the inactivity window has not elapsed.'
+  OwnerStillActive: 'The owner is still active; the inactivity window has not elapsed.',
+  // 0.5.0 additions
+  SignatureExpired: 'The signatures on this request have expired (validUntil has passed). Collect fresh signatures.',
+  RequiresOperationByte:
+    'This 0.5.0 wallet requires the operation-byte transaction format. Reset and re-sign this request.',
+  InvalidOperation: 'Unsupported operation byte: only CALL (0) and self-targeted DELEGATECALL (1) are allowed.',
+  NotApproved: 'You never approved this hash on-chain, so there is nothing to revoke.',
+  SensitiveCallRequiresDelay:
+    'This operation is protected by the timelock: schedule it, wait out the delay, then execute it.',
+  TimelockNotReady: 'The timelock delay has not elapsed yet for this scheduled transaction.',
+  AlreadyScheduled: 'This transaction is already scheduled.',
+  NotScheduled: 'This transaction was never scheduled (or was already cancelled).',
+  ScheduleExpired: 'The scheduled transaction expired (validUntil passed) before it was executed.',
+  NotSensitive: 'This call is not sensitive; execute it directly instead of scheduling it.',
+  ZeroDelayForSensitive: 'The timelock is disabled; set a delay before scheduling.',
+  DelayTooLong: 'The requested timelock delay exceeds the maximum the wallet accepts.',
+  GuardReverted: 'The transaction guard rejected this transaction.',
+  GuardIsZeroAddress: 'The guard cannot be the zero address.',
+  TargetNotAllowed: 'The target address is not on the wallet’s allowlist.',
+  TargetIsZeroAddress: 'The target cannot be the zero address.',
+  DailySpendingLimitExceeded: 'This transfer exceeds what remains of the owner’s daily spending allowance.',
+  AllowanceLimitNotSet: 'The connected owner has no daily spending allowance on this wallet.',
+  AllowanceRequiresSingleSigner: 'Allowance transfers take exactly one signature, from the sending owner.',
+  ModuleAlreadyEnabled: 'This module is already enabled.',
+  ModuleNotFound: 'This module is not enabled on the wallet.',
+  ModulePrevMismatch:
+    'The previous-module pointer does not match: pass the module right before this one (zero address for the first).',
+  ModuleIsZeroAddress: 'The module cannot be the zero address.',
+  NotAModule: 'Only an enabled module can use the module execution path.',
+  InvalidModuleOperation: 'Modules may only CALL, or DELEGATECALL into the wallet itself.',
+  NotEntryPoint: 'Only the ERC-4337 EntryPoint can call this function.',
+  InvalidNonce: 'The transaction nonce does not match the wallet’s current nonce.',
+  BatchCallFailed: 'A step of the atomic batch failed, so the whole batch reverted.',
+  MessageNotSigned: 'This message was never signed by the wallet.'
 }
 
 // Extracts a human-readable reason from a wagmi/viem contract error, decoding

--- a/src/utils/signatureBlob.ts
+++ b/src/utils/signatureBlob.ts
@@ -1,0 +1,35 @@
+import { encodeAbiParameters } from 'viem'
+
+import { isModernWallet } from './contractVersions'
+
+// Pre-0.5.0 wallets consume signatures as flat 65-byte r||s||v chunks
+// concatenated in signing order. 0.5.0 wallets consume an ABI-encoded
+// (address owner, bytes sig)[] instead — the owner is explicit per entry, and
+// `sig` may be a 65-byte ECDSA signature (EOA owner) or an EIP-1271 blob the
+// wallet staticcalls the owner contract with (nested-wallet owner).
+
+const OWNER_SIG_TUPLE = [
+  {
+    type: 'tuple[]',
+    components: [
+      { name: 'owner', type: 'address' },
+      { name: 'sig', type: 'bytes' }
+    ]
+  }
+] as const
+
+export const combineSignatures = (
+  walletVersion: string | undefined,
+  ownerSigners: string[],
+  signatures: string[]
+): `0x${string}` => {
+  if (signatures.length === 0) return '0x'
+  if (!isModernWallet(walletVersion))
+    return signatures.reduce((blob, sig) => blob + sig.replace(/^0x/, ''), '0x') as `0x${string}`
+  return encodeAbiParameters(OWNER_SIG_TUPLE, [
+    signatures.map((sig, i) => ({
+      owner: ownerSigners[i] as `0x${string}`,
+      sig: sig as `0x${string}`
+    }))
+  ])
+}

--- a/src/utils/transactionTypedData.ts
+++ b/src/utils/transactionTypedData.ts
@@ -1,0 +1,77 @@
+import { MultiSigExecTransactionArgs } from '../models/MultiSigs'
+import { isModernWallet } from './contractVersions'
+
+// The EIP-712 Transaction struct the wallet's typehash binds:
+// - pre-0.5.0 (all wallet classes):  (to, value, data, gas, nonce)
+// - 0.5.0 MyMultiSig:                + validUntil (0 = no expiry)
+// - 0.5.0 MyMultiSigExtended:        + operation  (0 = CALL, 1 = DELEGATECALL,
+//   bound into the hash even for plain calls — the pre-operation overloads
+//   revert with RequiresOperationByte on 0.5.0 Extended wallets)
+// Field names and order are part of the typehash; changing them breaks
+// isValidSignature on the corresponding deployment.
+
+const LEGACY_FIELDS = [
+  { name: 'to', type: 'address' },
+  { name: 'value', type: 'uint256' },
+  { name: 'data', type: 'bytes' },
+  { name: 'gas', type: 'uint256' },
+  { name: 'nonce', type: 'uint96' }
+] as const
+
+const VALID_UNTIL_FIELD = { name: 'validUntil', type: 'uint256' } as const
+const OPERATION_FIELD = { name: 'operation', type: 'uint8' } as const
+
+export type TransactionTypedDataInput = {
+  domain: { name: string; version: string; chainId: number | undefined; verifyingContract: `0x${string}` }
+  args: MultiSigExecTransactionArgs
+  // The nonce the signature binds: the pinned txnNonce when set, otherwise the
+  // wallet's current nonce.
+  nonce: bigint
+  walletVersion: string | undefined
+  isExtended: boolean
+}
+
+const isNumeric = (value: string | undefined): value is string =>
+  value != null && value !== '' && /^\d+$/.test(value)
+
+export const transactionValidUntil = (args: MultiSigExecTransactionArgs): bigint =>
+  isNumeric(args.validUntil) ? BigInt(args.validUntil) : 0n
+
+export const transactionOperation = (args: MultiSigExecTransactionArgs): number =>
+  args.operation === '1' ? 1 : 0
+
+// Broadly typed (not const-inferred): the struct shape is only known at
+// runtime, so consumers sign it as a dynamic typed-data definition.
+export type TransactionTypedData = {
+  domain: TransactionTypedDataInput['domain']
+  types: { Transaction: { name: string; type: string }[] }
+  primaryType: 'Transaction'
+  message: Record<string, unknown>
+}
+
+export const buildTransactionTypedData = ({
+  domain,
+  args,
+  nonce,
+  walletVersion,
+  isExtended
+}: TransactionTypedDataInput): TransactionTypedData => {
+  const modern = isModernWallet(walletVersion)
+  const types = {
+    Transaction: [
+      ...LEGACY_FIELDS,
+      ...(modern ? [VALID_UNTIL_FIELD] : []),
+      ...(modern && isExtended ? [OPERATION_FIELD] : [])
+    ]
+  }
+  const message = {
+    to: args.to,
+    value: isNumeric(args.value) ? BigInt(args.value) : 0n,
+    data: args.data,
+    gas: isNumeric(args.txnGas) ? BigInt(args.txnGas) : 0n,
+    nonce,
+    ...(modern ? { validUntil: transactionValidUntil(args) } : {}),
+    ...(modern && isExtended ? { operation: transactionOperation(args) } : {})
+  }
+  return { domain, types, primaryType: 'Transaction' as const, message }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14684,10 +14684,10 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mymultisig-contract@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/mymultisig-contract/-/mymultisig-contract-0.1.4.tgz#09530cb2d0e3eafc5c88ee75a749b6fc38efde3a"
-  integrity sha512-oNuiWaUGXPHXyYqqvmaEY+jHGfjC4J54tAeQEIHjcJFSStEz0S0XtA7OqlLZNmfS4eEURFPNk18laOx7Pv9fQA==
+mymultisig-contract@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/mymultisig-contract/-/mymultisig-contract-0.5.0.tgz#809ddd9ac20f1b770ee93ccce96f14d9a11fb4ff"
+  integrity sha512-y4S8Xp5n5YoOTn2fA6k6ufBlky6jfUBIHmYdnIx7vKs1HDir3N1Z3zNYHYlfX7mCE4qAasSj69DwUcPb0KMrTQ==
   dependencies:
     "@openzeppelin/contracts" "^4.8.3"
     "@openzeppelin/contracts-upgradeable" "^4.8.3"


### PR DESCRIPTION
## Summary

Upgrades `mymultisig-contract` from **0.1.4 → 0.5.0** and implements every feature the new version ships (spanning the contract's v0.2.0 → v0.5.0 releases), while keeping **every already-deployed pre-0.5.0 wallet and factory fully working** — the protocol surface (EIP-712 typehash, signature blob encoding, execTransaction overloads) now branches on the wallet's reported `version()`.

## Protocol core (version-aware)

- **EIP-712 typed data** (`src/utils/transactionTypedData.ts`): 0.5.0 wallets bind `validUntil` into the Transaction struct, and 0.5.0 Extended wallets additionally bind the `operation` byte; pre-0.5.0 wallets keep the original 5-field struct.
- **Signature blobs** (`src/utils/signatureBlob.ts`): 0.5.0 wallets consume ABI-encoded `(address owner, bytes sig)[]` (EIP-1271-capable — nested wallet owners can vote); legacy wallets keep flat 65-byte concatenation.
- **Execution** (`useExecTransaction`): picks the exact overload per wallet generation — the 0.5.0 Extended operation-byte overloads (8-arg pinned-nonce / 7-arg current-nonce; the old ones revert with `RequiresOperationByte`), the 0.5.0 base 6-arg with `validUntil`, or the legacy 5/6-arg calls. Because viem resolves overloads by argument count (which can't separate the two 7-arg Extended overloads), the write config filters the ABI to the exact overload. Watches the new `TransactionExecutedOp` / `TxFailureOp` events.
- **Approval preflight** (`useRequestApprovalState`): `generateHashOp` / 8-arg `isValidSignature` on 0.5.0 Extended, `validUntil`-flavored reads on 0.5.0 base, vendored legacy fragments for pre-0.5.0 wallets (the new package ABI dropped them).

## v0.3.0 features

- **`validUntil` deadlines**: optional expiry picker on request creation; expired requests are flagged and blocked from signing/execution; `SignatureExpired` decoded.
- **`revokeApproval`**: on-chain approvers can withdraw their approval from the request detail view.
- **`multiRequestStrict`**: "Atomic batch (all-or-nothing)" toggle on multi-step requests; strict batches mark all steps successful on execution (they revert as a whole otherwise).

## v0.4.0 features (Extended wallets)

- **Admin actions** for the whole new governance surface, version-gated: `setTimelockDelay`, `setSensitiveSelector`, `setSensitiveValueThreshold`, `setGuard`, `setAllowedTarget`, `setDailySpendingLimit`, `enableModule`, `disableModule` (with Safe-style prev-pointer guidance).
- **Timelock flow**: request detail embeds a schedule → wait → `executeScheduled` / `cancelScheduled` panel when the wallet configured a delay, with sensitivity preview (registered selectors / wei threshold) and the executed-sentinel handled.
- **Advanced features panel**: `advancedFeaturesEnabled()` bitmask overview (timelock, guard, allowlist, allowances, modules) with live per-feature detail incl. the `getModules()` list.
- **Spending allowances**: settings panel showing the connected owner's daily cap and rolling remaining amount, with a single-signer send via `execTransactionWithSpendingAllowance`.
- **Factory bookkeeping**: per-type creation counts (`simpleCount`/`extendedCount`/`advancedCount`) shown on the create form.

## v0.5.0 features

- **Operation byte / DELEGATECALL**: expert toggle on single self-targeted requests (`operation = 1`, gated on-chain to `to == wallet`).
- **ERC-4337**: settings panel showing the wallet's pinned EntryPoint v0.7 binding and its gas deposit, with `depositTo` prefunding (minimal vendored EntryPoint ABI).
- **EIP-1271 message signing**: check any message's `getMessageHash` / `isMessageSigned` status and create `signMessage` / `unsignMessage` self-call requests.
- **Factory create calls**: `createMyMultiSigExtended` / new `createMyMultiSigAdvanced` pass the canonical EntryPoint on 0.5.0 factories; the new **Advanced** wallet type card appears on 0.5.0 factories; `WalletType` grew `'advanced'`.

## Backwards compatibility

- Vendored legacy fragments (`src/constants/abi/legacy.ts`) for everything the 0.5.0 package ABI dropped but deployed contracts still speak: 5-arg `generateHash`, 6-arg `isValidSignature`, 4-arg `createMyMultiSigExtended`, the 2-deployer factory constructor (community factory deploys still use the pre-0.5.0 bytecode snapshot — the package ships no bytecode), and the removed `InvalidOwner`/`OwnerAlreadySigned` errors so legacy reverts keep decoding.
- Signing and execution are blocked until the wallet's version/type reads answer, so the wrong struct shape can never be signed.
- All 30+ new 0.5.0 custom errors get human-readable copy in `decodeContractError`.

## Notes / assumptions

- No 0.2.x–0.4.x wallets were ever deployed (the package jumped 0.1.4 → 0.5.0), so a single `>= 0.5.0` cutoff covers all breaking changes in between.
- The allowance flow signs the full 0.5.0 Extended typehash with `operation = 0` (consistent with the contract validating allowances "through the same signature-validation path used by execTransaction").
- `contractsAddressDeployed.json` is unchanged in 0.5.0, so all currently registered factories are pre-0.5.0; the 0.5.0 factory paths light up as soon as a 0.5.0 factory is registered.

## Testing

- `yarn build` passes (production build incl. all pages).
- `npx tsc --noEmit` clean; lint-staged (eslint + prettier) ran on every commit.
- Every new component ships a Storybook story per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)