### PR TITLE
feat: mymultisig-contract 0.5.1 — deterministic CREATE2 creation, getOwners, new governance surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lucide-react": "^0.577.0",
-    "mymultisig-contract": "0.5.0",
+    "mymultisig-contract": "0.5.1",
     "next-pwa": "^5.6.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.3",

--- a/src/components/forms/CreateMultiSigForm.tsx
+++ b/src/components/forms/CreateMultiSigForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { useChainId, useChains } from 'wagmi'
+import { keccak256, stringToHex } from 'viem'
 import { ExternalLinkIcon, CheckCircleIcon, CheckIcon, AddIcon, DeleteIcon, ArrowBackIcon } from '../icons/ChakraIcons'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Button } from '@/components/ui/button'
@@ -12,6 +13,7 @@ import ConfirmationCard from '../cards/ConfirmationCard'
 import { MultiSigFactory, MultiSigConstructorArgs, WalletType, isExtendedWallet } from '../../models/MultiSigs'
 import useCreateMultiSig from '../../hooks/useCreateMultiSig'
 import useFactoryStats from '../../hooks/useFactoryStats'
+import usePredictMultiSigAddress from '../../hooks/usePredictMultiSigAddress'
 import { isModernFactory } from '../../utils/contractVersions'
 
 interface CreateMultiSigFormProps {
@@ -104,10 +106,17 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
   const [threshold, setThreshold] = useState(1)
   const [walletType, setWalletType] = useState<WalletType>('simple')
   const [isOnlyOwnerRequest, setIsOnlyOwnerRequest] = useState(false)
+  const [deterministic, setDeterministic] = useState(false)
+  const [saltText, setSaltText] = useState('')
   // Advanced creation (createMyMultiSigAdvanced) only exists on 0.5.0 factories.
-  const availableTypes: readonly WalletType[] = isModernFactory(factory.version)
+  const modernFactory = isModernFactory(factory.version)
+  const availableTypes: readonly WalletType[] = modernFactory
     ? (['simple', 'extended', 'advanced'] as const)
     : (['simple', 'extended'] as const)
+  // The salt (hashed from the user's phrase) feeds createDeterministic*: the
+  // same phrase + creator + name/owners/threshold reproduces the same wallet
+  // address on every chain with the canonical factory set.
+  const salt = modernFactory && deterministic && saltText.trim() !== '' ? keccak256(stringToHex(saltText.trim())) : undefined
 
   const filledOwners = owners.filter((owner) => owner !== '')
   const ownersValid = filledOwners.length > 0 && filledOwners.every(isAddress)
@@ -124,17 +133,23 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
         ? `Duplicate owner: ${truncateAddress(duplicateOwners[0])}`
         : !thresholdValid
           ? 'Pick a signature threshold'
-          : null
+          : modernFactory && deterministic && salt == null
+            ? 'Enter a salt phrase for the deterministic address'
+            : null
 
   const constructorArgs: MultiSigConstructorArgs = {
     contractName: name,
     owners: filledOwners,
     threshold,
     walletType,
-    isOnlyOwnerRequest: isExtendedWallet(walletType) ? isOnlyOwnerRequest : undefined
+    isOnlyOwnerRequest: isExtendedWallet(walletType) ? isOnlyOwnerRequest : undefined,
+    salt
   }
 
   const { data, isPending, isSuccess, writeContract } = useCreateMultiSig(constructorArgs, factory.address)
+  // Only predicted on the review step: the inputs are settled there, so the
+  // read does not re-fire on every keystroke of the earlier steps.
+  const { predictedAddress } = usePredictMultiSigAddress(constructorArgs, factory.address, salt != null && step === 2)
   const { totalCount, simpleCount, extendedCount, advancedCount, supportsTypeCounts } = useFactoryStats(
     factory.address
   )
@@ -342,6 +357,33 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
             )}
           </div>
 
+          {modernFactory && (
+            <div className='flex w-full flex-col gap-3 rounded-xl border border-border bg-muted/30 p-4'>
+              <div className='flex items-center gap-3'>
+                <Switch checked={deterministic} onCheckedChange={setDeterministic} />
+                <div className='flex flex-col'>
+                  <span className='text-sm font-medium text-foreground'>Deterministic address (CREATE2)</span>
+                  <span className='text-xs text-muted-foreground'>
+                    Deploy at an address you can reproduce on every supported chain.
+                  </span>
+                </div>
+              </div>
+              {deterministic && (
+                <div className='flex w-full flex-col gap-1'>
+                  <TextInput
+                    placeholder='Salt phrase (e.g. my-team-treasury)'
+                    value={saltText}
+                    onChange={(e) => setSaltText(e.target.value)}
+                  />
+                  <span className='text-xs text-muted-foreground'>
+                    The same phrase, creator wallet, name, owners and threshold always produce the same address — keep
+                    the phrase to redeploy this wallet on another chain.
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
           <div className='flex w-full gap-2'>
             <Button variant='outline' size='lg' className='gap-2' onClick={() => setStep(0)}>
               <ArrowBackIcon className='h-4 w-4' />
@@ -384,6 +426,19 @@ const CreateMultiSigForm: React.FC<CreateMultiSigFormProps> = ({ owner01, factor
                 {threshold} of {filledOwners.length} owner{filledOwners.length === 1 ? '' : 's'}
               </span>
             </div>
+            {salt != null && (
+              <div className='flex flex-col gap-1 border-t border-border pt-3'>
+                <span className='text-muted-foreground'>Deterministic address</span>
+                {predictedAddress != null ? (
+                  <span className='break-all font-mono text-xs text-foreground'>{predictedAddress}</span>
+                ) : (
+                  <span className='text-xs text-muted-foreground'>Predicting the wallet address…</span>
+                )}
+                <span className='text-xs text-muted-foreground'>
+                  Redeploying with the same salt phrase and settings reproduces this address on other chains.
+                </span>
+              </div>
+            )}
             <div className='flex flex-col gap-1 border-t border-border pt-3'>
               <span className='text-muted-foreground'>Owners</span>
               {filledOwners.map((owner) => (

--- a/src/components/multiSigDetails/AdvancedFeaturesPanel.tsx
+++ b/src/components/multiSigDetails/AdvancedFeaturesPanel.tsx
@@ -34,12 +34,15 @@ const AdvancedFeaturesPanel: React.FC<AdvancedFeaturesPanelProps> = ({ multiSigA
     guard,
     allowedTargetsEnabled,
     sensitiveValueThreshold,
-    modules
+    modules,
+    requireTxSuccess
   } = useAdvancedFeatures(multiSigAddress)
 
   if (!supportsAdvanced) return null
 
-  const features: { label: string; bit: number; detail: React.ReactNode }[] = [
+  // Most cards reflect a bit of the advancedFeaturesEnabled bitmask; entries
+  // with an explicit `enabled` (the failure policy) sit outside the bitmask.
+  const features: { label: string; bit?: number; enabled?: boolean; detail: React.ReactNode }[] = [
     {
       label: 'Timelock',
       bit: FEATURE_TIMELOCK,
@@ -96,7 +99,18 @@ const AdvancedFeaturesPanel: React.FC<AdvancedFeaturesPanelProps> = ({ multiSigA
         ) : (
           'No modules enabled. Modules act for the wallet without owner signatures.'
         )
-    }
+    },
+    ...(requireTxSuccess != null
+      ? [
+          {
+            label: 'Require inner-call success',
+            enabled: requireTxSuccess,
+            detail: requireTxSuccess
+              ? 'On — an inner call that fails without revert data reverts the whole execution and preserves the nonce.'
+              : 'Off — an inner call that fails without revert data emits TxFailure and the nonce is consumed.'
+          }
+        ]
+      : [])
   ]
 
   return (
@@ -110,7 +124,7 @@ const AdvancedFeaturesPanel: React.FC<AdvancedFeaturesPanelProps> = ({ multiSigA
       </div>
       <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
         {features.map((feature) => {
-          const enabled = (featuresBitmask & feature.bit) !== 0
+          const enabled = feature.enabled ?? (feature.bit != null && (featuresBitmask & feature.bit) !== 0)
           return (
             <div key={feature.label} className='flex flex-col gap-1 rounded-lg border border-border p-3'>
               <div className='flex items-center justify-between gap-2'>

--- a/src/components/multiSigDetails/MultiSigOverview.tsx
+++ b/src/components/multiSigDetails/MultiSigOverview.tsx
@@ -66,7 +66,7 @@ const MultiSigOverview: React.FC<MultiSigOverviewProps> = ({ multiSigAddress }) 
   const chains = useChains()
   const chain = chains.find((c) => c.id === chainId)
   const { address } = useAccount()
-  const { multiSigDetails, data } = useMultiSigDetails(multiSigAddress, address ?? '0x')
+  const { multiSigDetails, data, onChainOwners, refetchOwners } = useMultiSigDetails(multiSigAddress, address ?? '0x')
   const { data: balance } = useBalance({ address: multiSigAddress, chainId: chain?.id })
   const { requests, isError: requestsError } = useMultiSigRequests(multiSigAddress)
   // A light scan (fewer RPC windows) is enough for a preview; the Activity tab
@@ -78,10 +78,12 @@ const MultiSigOverview: React.FC<MultiSigOverviewProps> = ({ multiSigAddress }) 
   const { multiSigs } = useMultiSigs()
   const { labelFor } = useAddressLabels(chain?.id)
   const [fundModalOpen, setFundModalOpen] = React.useState(false)
-  useAdminEventSync(multiSigAddress)
+  useAdminEventSync(multiSigAddress, refetchOwners)
 
   const stored = multiSigs.find((m) => m.address.toLowerCase() === multiSigAddress.toLowerCase())
-  const owners = stored?.owners ?? []
+  // 0.5.0 wallets report the authoritative list via getOwners(); older
+  // deployments fall back to the locally tracked one.
+  const owners = onChainOwners ?? stored?.owners ?? []
   const explorerUrl = chain?.blockExplorers?.default?.url
 
   if (multiSigDetails == null)
@@ -176,8 +178,8 @@ const MultiSigOverview: React.FC<MultiSigOverviewProps> = ({ multiSigAddress }) 
           ) : (
             <p className='text-sm text-muted-foreground'>
               {multiSigDetails.ownerCount} owner{multiSigDetails.ownerCount === 1 ? ' is' : 's are'} registered
-              on-chain. The contract stores owners as a mapping, so the app can only list addresses it has seen; owner
-              operations fill this in over time.
+              on-chain. Wallets deployed before 0.5.0 store owners as a bare mapping (no getOwners()), so the app can
+              only list addresses it has seen; owner operations fill this in over time.
             </p>
           )}
         </div>

--- a/src/components/views/MultiSigSettings.tsx
+++ b/src/components/views/MultiSigSettings.tsx
@@ -25,12 +25,14 @@ const MultiSigSettings: React.FC<MultiSigSettingsProps> = ({ multiSigAddress }) 
   const { address } = useAccount()
   const chainId = useChainId()
   const { labelFor } = useAddressLabels(chainId)
-  const { multiSigDetails, data } = useMultiSigDetails(multiSigAddress, address ?? '0x')
+  const { multiSigDetails, data, onChainOwners, refetchOwners } = useMultiSigDetails(multiSigAddress, address ?? '0x')
   const { walletType } = useWalletType(multiSigAddress)
   const { multiSigs } = useMultiSigs()
-  useAdminEventSync(multiSigAddress)
+  useAdminEventSync(multiSigAddress, refetchOwners)
   const stored = multiSigs.find((m) => m.address.toLowerCase() === multiSigAddress.toLowerCase())
-  const owners = stored?.owners ?? []
+  // 0.5.0 wallets report the authoritative list via getOwners(); older
+  // deployments fall back to the locally tracked one.
+  const owners = onChainOwners ?? stored?.owners ?? []
 
   if (multiSigDetails == null) return null
 
@@ -64,9 +66,9 @@ const MultiSigSettings: React.FC<MultiSigSettingsProps> = ({ multiSigAddress }) 
           ))
         ) : (
           <p className='text-sm text-muted-foreground'>
-            The contract stores owners as a mapping, so the app tracks the list locally: it is seeded at create/import
-            time and kept in sync from the wallet&apos;s OwnerAdded / OwnerRemoved events as owner operations execute.{' '}
-            {multiSigDetails.ownerCount} owner
+            Wallets deployed before 0.5.0 store owners as a bare mapping (no getOwners()), so the app tracks the list
+            locally: it is seeded at create/import time and kept in sync from the wallet&apos;s OwnerAdded /
+            OwnerRemoved events as owner operations execute. {multiSigDetails.ownerCount} owner
             {multiSigDetails.ownerCount === 1 ? ' is' : 's are'} registered on-chain.
           </p>
         )}

--- a/src/hooks/useAdminEventSync.ts
+++ b/src/hooks/useAdminEventSync.ts
@@ -10,7 +10,9 @@ import persistMultiSigWalletPatch from '../utils/persistWallet'
 // ThresholdChanged). This also picks up changes executed by other clients,
 // which the decode-the-self-call path in useExecTransaction cannot see.
 // All patches are idempotent so overlapping sync paths cannot double-apply.
-const useAdminEventSync = (multiSigAddress: `0x${string}`) => {
+// onOwnersChanged fires on every owner event so callers can refresh cached
+// on-chain reads (the getOwners() list on 0.5.0 wallets) alongside the store.
+const useAdminEventSync = (multiSigAddress: `0x${string}`, onOwnersChanged?: () => void) => {
   const chainId = useChainId()
   const { multiSigs, updateMultiSig } = useMultiSigs()
   const enabled = /^0x[a-fA-F0-9]{40}$/.test(multiSigAddress)
@@ -29,8 +31,9 @@ const useAdminEventSync = (multiSigAddress: `0x${string}`) => {
     abi: MyMultiSig,
     eventName: 'OwnerAdded',
     enabled,
-    onLogs: (logs) =>
-       
+    onLogs: (logs) => {
+      if (logs.length > 0) onOwnersChanged?.()
+
       logs.forEach((log: any) => {
         const owner = String(log.args?.owner ?? '')
         if (!owner) return
@@ -40,6 +43,7 @@ const useAdminEventSync = (multiSigAddress: `0x${string}`) => {
             : { owners: [...stored.owners, owner], ownerCount: stored.ownerCount + 1 }
         )
       })
+    }
   })
 
   useWatchContractEvent({
@@ -47,8 +51,9 @@ const useAdminEventSync = (multiSigAddress: `0x${string}`) => {
     abi: MyMultiSig,
     eventName: 'OwnerRemoved',
     enabled,
-    onLogs: (logs) =>
-       
+    onLogs: (logs) => {
+      if (logs.length > 0) onOwnersChanged?.()
+
       logs.forEach((log: any) => {
         const owner = String(log.args?.owner ?? '')
         if (!owner) return
@@ -61,6 +66,7 @@ const useAdminEventSync = (multiSigAddress: `0x${string}`) => {
             : null
         )
       })
+    }
   })
 
   useWatchContractEvent({

--- a/src/hooks/useAdvancedFeatures.ts
+++ b/src/hooks/useAdvancedFeatures.ts
@@ -29,7 +29,10 @@ const useAdvancedFeatures = (multiSigAddress: `0x${string}`) => {
       { ...base, functionName: 'allowedTargetsEnabled' },
       { ...base, functionName: 'sensitiveValueThreshold' },
       { ...base, functionName: 'getModules' },
-      { ...base, functionName: 'ENTRY_POINT' }
+      { ...base, functionName: 'ENTRY_POINT' },
+      // 0.5.0 failure policy; reverts on wallets predating setRequireTxSuccess,
+      // so requireTxSuccess stays undefined there and the panel hides the card.
+      { ...base, functionName: 'requireTxSuccess' }
     ],
     allowFailure: true,
     query: { enabled: multiSigAddress !== '0x', retry: false }
@@ -48,6 +51,7 @@ const useAdvancedFeatures = (multiSigAddress: `0x${string}`) => {
     sensitiveValueThreshold: at<bigint>(4),
     modules: (at<readonly `0x${string}`[]>(5) ?? []).map(String) as `0x${string}`[],
     entryPoint: at<`0x${string}`>(6),
+    requireTxSuccess: at<boolean>(7),
     isLoading,
     refetch
   }

--- a/src/hooks/useCreateMultiSig.ts
+++ b/src/hooks/useCreateMultiSig.ts
@@ -28,6 +28,9 @@ const useCreateMultiSig = (constructorArgs: MultiSigConstructorArgs, multiSigFac
     (f) => f.chainId === chain?.id && f.address.toLowerCase() === multiSigFactoryAddress.toLowerCase()
   )?.version
   const modernFactory = isModernFactory(factoryVersion)
+  // 0.5.0 factories also expose the CREATE2 path: same creator + salt + args
+  // -> same wallet address on every chain the factory set is deployed at.
+  const deterministic = modernFactory && constructorArgs.salt != null
   const config = {
     chainId: chain?.id,
     address: multiSigFactoryAddress,
@@ -40,18 +43,30 @@ const useCreateMultiSig = (constructorArgs: MultiSigConstructorArgs, multiSigFac
         : (MyMultiSigFactory as JsonFragment[]),
     functionName: (isExtended
       ? modernFactory && constructorArgs.walletType === 'advanced'
-        ? 'createMyMultiSigAdvanced'
-        : 'createMyMultiSigExtended'
-      : 'createMultiSig') as string,
+        ? deterministic
+          ? 'createDeterministicMyMultiSigAdvanced'
+          : 'createMyMultiSigAdvanced'
+        : deterministic
+          ? 'createDeterministicMyMultiSigExtended'
+          : 'createMyMultiSigExtended'
+      : deterministic
+        ? 'createDeterministicMultiSig'
+        : 'createMultiSig') as string,
     args: isExtended
       ? ([
           constructorArgs.contractName,
           constructorArgs.owners,
           constructorArgs.threshold,
           constructorArgs.isOnlyOwnerRequest ?? false,
-          ...(modernFactory ? [contractConstants.ENTRY_POINT_V07_ADDRESS] : [])
+          ...(modernFactory ? [contractConstants.ENTRY_POINT_V07_ADDRESS] : []),
+          ...(deterministic ? [constructorArgs.salt] : [])
         ] as const)
-      : ([constructorArgs.contractName, constructorArgs.owners, constructorArgs.threshold] as const)
+      : ([
+          constructorArgs.contractName,
+          constructorArgs.owners,
+          constructorArgs.threshold,
+          ...(deterministic ? [constructorArgs.salt] : [])
+        ] as const)
   }
   const {
     data,

--- a/src/hooks/useFinalizeTransaction.ts
+++ b/src/hooks/useFinalizeTransaction.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useWriteContract, useWaitForTransactionReceipt } from 'wagmi'
+import { useAccount, useSwitchChain, useWriteContract, useWaitForTransactionReceipt } from 'wagmi'
 import { toast } from 'sonner'
 import { JsonFragment } from '@ethersproject/abi'
 
@@ -18,7 +18,26 @@ const useFinalizeTransaction = <TFunctionName extends string>(
   notificationError: () => void
 ) => {
   const { data, error, isPending, isSuccess, isError, writeContract: writeContractFn, writeContractAsync, reset, status } = useWriteContract()
-  
+  const { chainId: walletChainId } = useAccount()
+  const { switchChainAsync } = useSwitchChain()
+
+  // The wallet can sit on a different chain than the app (the header selector
+  // only moves the app state when the connector will not follow), and wagmi's
+  // writeContract hard-errors on the mismatch instead of prompting. Ask the
+  // wallet to switch to the target chain first, and only then submit.
+  const ensureWalletChain = async (): Promise<boolean> => {
+    if (config.chainId == null || walletChainId === config.chainId) return true
+    try {
+      await switchChainAsync({ chainId: config.chainId })
+      return true
+    } catch (switchError) {
+      console.error('Chain switch rejected', switchError)
+      toast.error('Switch your wallet to the selected network to continue.')
+      notificationError()
+      return false
+    }
+  }
+
   // Handle errors and success via useEffect or mutation callbacks
   React.useEffect(() => {
     if (error) {
@@ -64,8 +83,15 @@ const useFinalizeTransaction = <TFunctionName extends string>(
     isError,
     isPending,
     isSuccess,
-    writeContract: () => writeContractFn(config),
-    writeContractAsync: () => writeContractAsync(config),
+    writeContract: () => {
+      ensureWalletChain().then((ok) => {
+        if (ok) writeContractFn(config)
+      })
+    },
+    writeContractAsync: async () => {
+      if (!(await ensureWalletChain())) throw new Error('The wallet is not on the selected network.')
+      return writeContractAsync(config)
+    },
     reset,
     status,
     dataFinal,

--- a/src/hooks/useFundMultiSig.ts
+++ b/src/hooks/useFundMultiSig.ts
@@ -1,6 +1,7 @@
 import React from 'react'
 import { erc20Abi } from 'viem'
 import { useChainId, useSendTransaction, useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
+import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import decodeContractError from '../utils/decodeContractError'
@@ -11,6 +12,7 @@ import { useNotification } from './notifications'
 // so this bypasses the request/approval machinery entirely.
 const useFundMultiSig = (multiSigAddress: `0x${string}`) => {
   const chainId = useChainId()
+  const queryClient = useQueryClient()
   const { notificationInfo, notificationError, notificationSuccess } = useNotification()
   const native = useSendTransaction()
   const token = useWriteContract()
@@ -45,7 +47,15 @@ const useFundMultiSig = (multiSigAddress: `0x${string}`) => {
   React.useEffect(() => {
     if (isFinal && receipt) {
       notificationSuccess()
+      // The pages under the modal read balances through cached wagmi queries
+      // (the multisig's native balance tile, ERC-20 reads); invalidate them so
+      // the new funds show up without a hard refresh.
+      queryClient.invalidateQueries({ queryKey: ['balance'] })
+      queryClient.invalidateQueries({ queryKey: ['readContract'] })
+      queryClient.invalidateQueries({ queryKey: ['readContracts'] })
     }
+    // queryClient is stable; the receipt is the real dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFinal, receipt, notificationSuccess])
 
   const fundNative = (amount: bigint) => native.sendTransaction({ chainId, to: multiSigAddress, value: amount })

--- a/src/hooks/useMultiSigDetails.ts
+++ b/src/hooks/useMultiSigDetails.ts
@@ -1,4 +1,4 @@
-import { useChainId, useChains, useReadContracts } from 'wagmi'
+import { useChainId, useChains, useReadContract, useReadContracts } from 'wagmi'
 import MyMultiSig from 'mymultisig-contract/abi/MyMultiSig.json'
 
 import { MultiSigOnChainData } from '../models/MultiSigs'
@@ -10,6 +10,17 @@ const useMultiSigDetails = (multiSigAddress: `0x${string}`, address: `0x${string
     abi: MyMultiSig,
     chainId: chain?.id
   }
+  // 0.5.0 wallets enumerate owners on-chain; the read reverts on older
+  // deployments (owners were a bare mapping), so it stays out of the
+  // allowFailure:false batch below and consumers fall back to the locally
+  // tracked list when onChainOwners is undefined.
+  const { data: ownersData, refetch: refetchOwners } = useReadContract({
+    ...myMultiSig,
+    functionName: 'getOwners',
+    query: { enabled: multiSigAddress !== '0x', retry: false }
+  })
+  const onChainOwners =
+    ownersData != null ? (ownersData as readonly string[]).map(String) : undefined
   const { data, error, isError, isLoading, isSuccess, isFetched, isRefetching, refetch, status } =
     useReadContracts({
       contracts: [
@@ -54,10 +65,12 @@ const useMultiSigDetails = (multiSigAddress: `0x${string}`, address: `0x${string
       threshold: Number(data[2]),
       ownerCount: Number(data[3]),
       nonce: Number(data[4]),
-      owners: [address]
+      owners: onChainOwners ?? [address]
     }
     return {
           multiSigDetails,
+          onChainOwners,
+          refetchOwners,
           data,
           error,
           isError,
@@ -71,6 +84,8 @@ const useMultiSigDetails = (multiSigAddress: `0x${string}`, address: `0x${string
       } else {
     return {
           multiSigDetails: null,
+          onChainOwners,
+          refetchOwners,
           data,
           error,
           isError,

--- a/src/hooks/usePredictMultiSigAddress.ts
+++ b/src/hooks/usePredictMultiSigAddress.ts
@@ -1,0 +1,60 @@
+import { useAccount, useChainId, useChains, useReadContract } from 'wagmi'
+import MyMultiSigFactory from 'mymultisig-contract/abi/MyMultiSigFactory.json'
+import contractConstants from 'mymultisig-contract/constants'
+
+import { MultiSigConstructorArgs, isExtendedWallet } from '../models/MultiSigs'
+
+// Preview of the CREATE2 wallet address a 0.5.0 factory would deploy for the
+// connected creator + salt + constructor arguments (predict*Address mirrors
+// what createDeterministic* will do). The read reverts on factories without
+// the deterministic surface, in which case predictedAddress stays undefined.
+const usePredictMultiSigAddress = (
+  constructorArgs: MultiSigConstructorArgs,
+  multiSigFactoryAddress: `0x${string}`,
+  enabled: boolean
+) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { address: account } = useAccount()
+  const isExtended = isExtendedWallet(constructorArgs.walletType)
+
+  const { data, isLoading } = useReadContract({
+    chainId: chain?.id,
+    address: multiSigFactoryAddress,
+    abi: MyMultiSigFactory,
+    functionName: isExtended
+      ? constructorArgs.walletType === 'advanced'
+        ? 'predictMyMultiSigAdvancedAddress'
+        : 'predictMyMultiSigExtendedAddress'
+      : 'predictMultiSigAddress',
+    args: isExtended
+      ? [
+          account ?? '0x',
+          constructorArgs.contractName,
+          constructorArgs.owners,
+          constructorArgs.threshold,
+          constructorArgs.isOnlyOwnerRequest ?? false,
+          contractConstants.ENTRY_POINT_V07_ADDRESS,
+          constructorArgs.salt ?? '0x'
+        ]
+      : [
+          account ?? '0x',
+          constructorArgs.contractName,
+          constructorArgs.owners,
+          constructorArgs.threshold,
+          constructorArgs.salt ?? '0x'
+        ],
+    query: {
+      enabled: enabled && account != null && constructorArgs.salt != null && constructorArgs.owners.length > 0,
+      retry: false
+    }
+  })
+
+  return {
+    predictedAddress: data != null ? (String(data) as `0x${string}`) : undefined,
+    isLoading
+  }
+}
+
+export default usePredictMultiSigAddress

--- a/src/hooks/useScheduledTransaction.ts
+++ b/src/hooks/useScheduledTransaction.ts
@@ -14,9 +14,10 @@ export const SCHEDULE_EXECUTED_SENTINEL = 2n ** 256n - 1n
 // registered selector, or value above the configured threshold) revert on the
 // direct execTransaction path with SensitiveCallRequiresDelay and must go
 // schedule -> wait timelockDelay -> executeScheduled instead. The schedule is
-// keyed by the transaction hash, consumes the same owner signatures as a
-// direct execution, and binds the request's validUntil across the whole
-// window. cancelScheduled needs no signatures (any owner).
+// keyed by the transaction hash and consumes the owner signatures at
+// scheduleTransaction time; executeScheduled needs none (the schedule entry
+// is the authorization) and cancelScheduled takes just the schedule's tx hash
+// (any owner, no signatures).
 const useScheduledTransaction = (
   multiSigAddress: `0x${string}`,
   request: MultiSigTransactionRequest,
@@ -102,7 +103,7 @@ const useScheduledTransaction = (
     {
       ...base,
       functionName: 'executeScheduled',
-      args: [...(scheduleArgs ?? []), signatures]
+      args: scheduleArgs ?? []
     },
     notificationInfo,
     notificationSuccess,
@@ -112,7 +113,7 @@ const useScheduledTransaction = (
     {
       ...base,
       functionName: 'cancelScheduled',
-      args: scheduleArgs ?? []
+      args: [txHash ?? '0x']
     },
     notificationInfo,
     notificationSuccess,

--- a/src/hooks/useSpendingAllowance.ts
+++ b/src/hooks/useSpendingAllowance.ts
@@ -6,15 +6,16 @@ import { JsonFragment } from '@ethersproject/abi'
 
 import useMultiSigDetails from './useMultiSigDetails'
 import decodeContractError from '../utils/decodeContractError'
-import { buildTransactionTypedData } from '../utils/transactionTypedData'
+import { buildAllowanceTypedData } from '../utils/transactionTypedData'
 
 // Per-owner daily allowance (0.5.0 Extended wallets): a single owner with a
 // non-zero daily cap can move funds with just their own EIP-712 signature —
 // no threshold, no other owners. The wallet enforces a rolling 24h window and
 // only debits the cap when the inner call succeeds. The signature binds the
-// wallet's CURRENT nonce against the full 0.5.0 Extended typehash
-// (operation = 0), and the transaction must be sent by the signing owner
-// (the contract recovers the signer and requires it to be msg.sender).
+// dedicated AllowanceTransaction typehash to the wallet's allowanceNonce()
+// (bumped on every use, so a signature is single-use and can never replay
+// against execTransaction), and the transaction must be sent by the signing
+// owner (the contract recovers the signer and requires it to be msg.sender).
 const useSpendingAllowance = (multiSigAddress: `0x${string}`) => {
   const chainId = useChainId()
   const chains = useChains()
@@ -45,22 +46,34 @@ const useSpendingAllowance = (multiSigAddress: `0x${string}`) => {
     args: [address ?? '0x'],
     query: { enabled, retry: false }
   })
+  const { data: allowanceNonce, refetch: refetchAllowanceNonce } = useReadContract({
+    ...base,
+    functionName: 'allowanceNonce',
+    query: { enabled, retry: false }
+  })
 
   const spend = async (to: `0x${string}`, valueWei: string, txnGas: string) => {
     if (!publicClient || details == null || chain == null || isPending) return
+    if (allowanceNonce == null) {
+      toast.error('The allowance nonce has not loaded yet — try again in a moment.')
+      refetchAllowanceNonce()
+      return
+    }
     setIsPending(true)
     try {
-      const typedData = buildTransactionTypedData({
+      const typedData = buildAllowanceTypedData({
         domain: {
           name: String(details[0]),
           version: String(details[1]),
           chainId: chain.id,
           verifyingContract: multiSigAddress
         },
-        args: { to, value: valueWei, data: '0x', txnGas, signatures: '' },
-        nonce: BigInt(String(details[4])),
-        walletVersion: String(details[1]),
-        isExtended: true
+        to,
+        value: BigInt(valueWei),
+        data: '0x',
+        gas: BigInt(txnGas),
+        allowanceNonce: BigInt(String(allowanceNonce)),
+        validUntil: 0n
       })
       const signature = await signTypedDataAsync(typedData as never)
       const hash = await writeContractAsync({
@@ -74,6 +87,7 @@ const useSpendingAllowance = (multiSigAddress: `0x${string}`) => {
       toast.success('Allowance transfer confirmed')
       setIsSuccess(true)
       refetchRemaining()
+      refetchAllowanceNonce()
     } catch (spendError) {
       console.error('Spending allowance error', spendError)
       const reason = decodeContractError(spendError)
@@ -94,6 +108,7 @@ const useSpendingAllowance = (multiSigAddress: `0x${string}`) => {
     refetch: () => {
       refetchLimit()
       refetchRemaining()
+      refetchAllowanceNonce()
     }
   }
 }

--- a/src/hooks/useSpendingAllowance.ts
+++ b/src/hooks/useSpendingAllowance.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useAccount, useChainId, useChains, usePublicClient, useReadContract, useSignTypedData, useWriteContract } from 'wagmi'
+import { useAccount, useChainId, useChains, usePublicClient, useReadContract, useSignTypedData, useSwitchChain, useWriteContract } from 'wagmi'
 import { toast } from 'sonner'
 import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
 import { JsonFragment } from '@ethersproject/abi'
@@ -20,7 +20,8 @@ const useSpendingAllowance = (multiSigAddress: `0x${string}`) => {
   const chainId = useChainId()
   const chains = useChains()
   const chain = chains.find((c) => c.id === chainId)
-  const { address } = useAccount()
+  const { address, chainId: walletChainId } = useAccount()
+  const { switchChainAsync } = useSwitchChain()
   const publicClient = usePublicClient()
   const { data: details } = useMultiSigDetails(multiSigAddress, address ?? '0x')
   const { signTypedDataAsync } = useSignTypedData()
@@ -61,6 +62,9 @@ const useSpendingAllowance = (multiSigAddress: `0x${string}`) => {
     }
     setIsPending(true)
     try {
+      // The signature domain and the write both target the app's chain; bring
+      // the wallet there first or wagmi rejects the write with ChainMismatch.
+      if (walletChainId !== chain.id) await switchChainAsync({ chainId: chain.id })
       const typedData = buildAllowanceTypedData({
         domain: {
           name: String(details[0]),

--- a/src/models/MultiSigs.ts
+++ b/src/models/MultiSigs.ts
@@ -39,6 +39,10 @@ export type MultiSigConstructorArgs = {
   threshold: number
   walletType?: WalletType
   isOnlyOwnerRequest?: boolean
+  // 0.5.0 factories only: bytes32 CREATE2 salt. When set, creation goes
+  // through createDeterministic* so the same creator + salt + constructor
+  // arguments yield the same wallet address on every chain.
+  salt?: `0x${string}`
 }
 
 export type BatchStep = {

--- a/src/utils/adminActions.ts
+++ b/src/utils/adminActions.ts
@@ -160,6 +160,18 @@ export const ADMIN_ACTIONS: AdminActionDefinition[] = [
     validate: () => null
   },
   {
+    id: 'setRequireTxSuccess',
+    group: 'policy',
+    label: 'Require inner-call success',
+    availableOn: 'both',
+    minWalletVersion: '0.5.0',
+    hint: 'When enabled, an inner call that fails without revert data reverts the whole execution and preserves the nonce, instead of emitting TxFailure and consuming it. Calls failing with revert data always revert the execution.',
+    fields: [{ key: 'required', label: 'Revert when the inner call fails', kind: 'boolean' }],
+    describe: (v) => `${v.required === 'true' ? 'Require' : 'Stop requiring'} inner-call success`,
+    buildArgs: (v) => [v.required === 'true'],
+    validate: () => null
+  },
+  {
     id: 'markNonceAsUsed',
     group: 'nonce',
     label: 'Burn a nonce',
@@ -287,6 +299,19 @@ export const ADMIN_ACTIONS: AdminActionDefinition[] = [
     validate: (v) => (isAddress(v.target) ? null : 'Enter a valid target address')
   },
   {
+    id: 'disableAllowlist',
+    group: 'security',
+    label: 'Turn off the target allowlist',
+    availableOn: 'extended',
+    minWalletVersion: '0.5.0',
+    danger: true,
+    hint: 'Switches the target allowlist off in one operation: the wallet can call any address again. Allowing a target later turns it back on.',
+    fields: [],
+    describe: () => 'Disable the target allowlist (the wallet may call any address again)',
+    buildArgs: () => [],
+    validate: () => null
+  },
+  {
     id: 'setDailySpendingLimit',
     group: 'allowance',
     label: 'Set a daily spending limit',
@@ -372,11 +397,12 @@ export const decodeSelfCall = (data: `0x${string}`): { functionName: string; arg
 }
 
 // Applies the effect of an executed self-call to the locally stored wallet so
-// owners/threshold stay in sync immediately (the contract stores owners as a
-// mapping, so there is no getOwners() to re-read). The OwnerAdded/OwnerRemoved/
-// ThresholdChanged event watchers in useAdminEventSync cover the same ground
-// for changes made by other clients; every patch here is idempotent so the two
-// paths cannot double-apply.
+// owners/threshold stay in sync immediately (pre-0.5.0 wallets store owners as
+// a bare mapping with no getOwners() to re-read; 0.5.0 wallets are re-read
+// live but the stored list still backs imports and older deployments). The
+// OwnerAdded/OwnerRemoved/ThresholdChanged event watchers in useAdminEventSync
+// cover the same ground for changes made by other clients; every patch here is
+// idempotent so the two paths cannot double-apply.
 export const applyAdminActionToMultiSig = (data: `0x${string}`, multiSig: MultiSig): Partial<MultiSig> | null => {
   const decoded = decodeSelfCall(data)
   if (!decoded) return null

--- a/src/utils/transactionTypedData.ts
+++ b/src/utils/transactionTypedData.ts
@@ -49,6 +49,51 @@ export type TransactionTypedData = {
   message: Record<string, unknown>
 }
 
+// 0.5.1 wallets domain-separate the single-signer allowance path: it signs a
+// dedicated AllowanceTransaction struct bound to the wallet's allowanceNonce()
+// (not the transaction nonce), so an allowance signature can never be replayed
+// against execTransaction or re-used after a failed inner call.
+export type AllowanceTypedDataInput = {
+  domain: TransactionTypedDataInput['domain']
+  to: `0x${string}`
+  value: bigint
+  data: `0x${string}`
+  gas: bigint
+  allowanceNonce: bigint
+  validUntil: bigint
+}
+
+export type AllowanceTypedData = {
+  domain: TransactionTypedDataInput['domain']
+  types: { AllowanceTransaction: { name: string; type: string }[] }
+  primaryType: 'AllowanceTransaction'
+  message: Record<string, unknown>
+}
+
+export const buildAllowanceTypedData = ({
+  domain,
+  to,
+  value,
+  data,
+  gas,
+  allowanceNonce,
+  validUntil
+}: AllowanceTypedDataInput): AllowanceTypedData => ({
+  domain,
+  types: {
+    AllowanceTransaction: [
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'data', type: 'bytes' },
+      { name: 'gas', type: 'uint256' },
+      { name: 'nonce', type: 'uint96' },
+      { name: 'validUntil', type: 'uint256' }
+    ]
+  },
+  primaryType: 'AllowanceTransaction' as const,
+  message: { to, value, data, gas, nonce: allowanceNonce, validUntil }
+})
+
 export const buildTransactionTypedData = ({
   domain,
   args,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14684,10 +14684,10 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mymultisig-contract@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/mymultisig-contract/-/mymultisig-contract-0.5.0.tgz#809ddd9ac20f1b770ee93ccce96f14d9a11fb4ff"
-  integrity sha512-y4S8Xp5n5YoOTn2fA6k6ufBlky6jfUBIHmYdnIx7vKs1HDir3N1Z3zNYHYlfX7mCE4qAasSj69DwUcPb0KMrTQ==
+mymultisig-contract@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mymultisig-contract/-/mymultisig-contract-0.5.1.tgz#997f57e40bfa8e3c41b94df26689fa45882ff5cd"
+  integrity sha512-vjZlFoFNSXJx6DsMmoYJV0saX0OkezOlomSfMwvXCAQqmrG1WTnkUMIzqfagTy8Va6mwGvujPsXxPAODuZnfkQ==
   dependencies:
     "@openzeppelin/contracts" "^4.8.3"
     "@openzeppelin/contracts-upgradeable" "^4.8.3"


### PR DESCRIPTION
## Summary

Updates `mymultisig-contract` to **0.5.1** and integrates every new contract feature. The package's address book now points at the freshly deployed Sepolia v0.5.0 factory (`0x2eE7e3532806cd6D7904ed8bD184665b0e3F95e2`, with the Simple/Extended/Advanced deployer set), so **new multisigs automatically deploy through the latest factory and wallet version** — the store re-injects package factories over stale persisted lists, switching existing users over on load.

### Deterministic CREATE2 creation
- Create form gains an opt-in **"Deterministic address (CREATE2)"** toggle with a salt phrase (hashed to the bytes32 salt); creation goes through `createDeterministicMultiSig` / `createDeterministicMyMultiSigExtended` / `createDeterministicMyMultiSigAdvanced`.
- The review step shows the wallet address predicted via `predict*Address` (new `usePredictMultiSigAddress` hook) — the same phrase, creator and settings reproduce the same address on every chain.

### getOwners()
- Overview and settings owner lists now prefer the authoritative on-chain `getOwners()` (0.5.0 wallets), falling back to the locally tracked list for older mapping-only deployments; `OwnerAdded`/`OwnerRemoved` events refetch the cached read.

### New governance controls
- `setRequireTxSuccess` (both wallet classes) and `disableAllowlist` (Extended) join the admin-action registry; the advanced-features panel shows the failure-policy state via a feature-detected `requireTxSuccess()` read.

### 0.5.1 transaction shapes
- `executeScheduled` no longer passes the signatures blob; `cancelScheduled` is keyed by the schedule's tx hash.
- The allowance path signs the dedicated `AllowanceTransaction` EIP-712 typehash bound to `allowanceNonce()` (replay fix) instead of the wallet nonce.
- Removed `executeUserOp`/`UserOpExecuted` were never consumed by the app — no-op.

No deployed wallet uses the old shapes: the only prior factory reports `version() = 0.1.1` (verified on-chain) and its wallets never had the scheduled/allowance surface, so the existing `>= 0.5.0` gates stay unambiguous.

## Verification

- `yarn build` passes.
- Driven end-to-end headlessly (anvil fork of Sepolia + injected wallet): the create flow predicted `0x3e197Fe964Bc5F223BCf2771c815Fe758c871dE4` and the deployed wallet landed **at exactly that address**; `getOwners()` populates the settings page; the new governance card and admin actions render.
- Multi-agent code review over the diff; its real findings (stuck salt validation after a network switch, stale cached owner list, silent allowance no-op) are fixed in the branch.

## Out of scope

- The community factory-deploy flow (`useDeployFactory`) still uses the vendored pre-0.5.0 bytecode snapshot; refreshing it to the 0.5.0 deployer set (incl. the EIP-170 split deployer from mymultisig-contract#226) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)