### PR TITLE
feat(settings): friendly duration / ether / selector inputs

### DIFF
--- a/src/components/forms/AdminActionForm.tsx
+++ b/src/components/forms/AdminActionForm.tsx
@@ -1,10 +1,16 @@
 import React, { useState } from 'react'
-import { useAccount } from 'wagmi'
+import { useAccount, useChainId, useChains } from 'wagmi'
+import type { Abi } from 'viem'
+import MyMultiSig from 'mymultisig-contract/abi/MyMultiSig.json'
+import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 
 import TextInput from '../inputs/TextInput'
+import DurationInput from '../inputs/DurationInput'
+import EthersInput from '../inputs/EthersInput'
+import HexSelectorInput from '../inputs/HexSelectorInput'
 import SignRequest from '../buttons/SignRequest'
 import useMultiSigDetails from '../../hooks/useMultiSigDetails'
 import useWalletType from '../../hooks/useWalletType'
@@ -21,6 +27,10 @@ const DEFAULT_ADMIN_GAS = '75000'
 // Actions are grouped by concern; selecting one expands its form inline.
 const AdminActionForm: React.FC<AdminActionFormProps> = ({ multiSigAddress }) => {
   const { address } = useAccount()
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const nativeSymbol = chain?.nativeCurrency.symbol ?? 'ETH'
   const { multiSigDetails } = useMultiSigDetails(multiSigAddress, address ?? '0x')
   const { walletType } = useWalletType(multiSigAddress)
   const [actionId, setActionId] = useState<string>('')
@@ -28,6 +38,13 @@ const AdminActionForm: React.FC<AdminActionFormProps> = ({ multiSigAddress }) =>
 
   const actions = adminActionsFor(walletType, multiSigDetails?.version)
   const action = actions.find((a) => a.id === actionId)
+
+  // Wallet ABIs HexSelectorInput can name for the user. The base wallet covers
+  // every wallet; the Extended ABIs add the 0.5.0-only surface that the
+  // timelock-sensitive-selector action is most likely to flip on.
+  const walletAbis: Abi[] = walletType === 'extended'
+    ? [MyMultiSigExtended as Abi, MyMultiSig as Abi]
+    : [MyMultiSig as Abi]
 
   const details = {
     threshold: multiSigDetails?.threshold ?? 1,
@@ -127,6 +144,33 @@ const AdminActionForm: React.FC<AdminActionFormProps> = ({ multiSigAddress }) =>
                         onCheckedChange={(checked) => setValues({ ...values, [field.key]: String(checked) })}
                       />
                       <span className='text-sm text-foreground'>{field.label}</span>
+                    </div>
+                  ) : field.kind === 'duration' ? (
+                    <div key={field.key} className='flex flex-col gap-1'>
+                      <span className='text-sm font-semibold text-foreground'>{field.label}</span>
+                      <DurationInput
+                        value={values[field.key] ?? ''}
+                        minSeconds={field.minSeconds}
+                        onChange={(next) => setValues({ ...values, [field.key]: next })}
+                      />
+                    </div>
+                  ) : field.kind === 'ethers' ? (
+                    <div key={field.key} className='flex flex-col gap-1'>
+                      <span className='text-sm font-semibold text-foreground'>{field.label}</span>
+                      <EthersInput
+                        symbol={nativeSymbol}
+                        value={values[field.key] ?? ''}
+                        onChange={(next) => setValues({ ...values, [field.key]: next })}
+                      />
+                    </div>
+                  ) : field.kind === 'selector' ? (
+                    <div key={field.key} className='flex flex-col gap-1'>
+                      <span className='text-sm font-semibold text-foreground'>{field.label}</span>
+                      <HexSelectorInput
+                        abis={walletAbis}
+                        value={values[field.key] ?? ''}
+                        onChange={(next) => setValues({ ...values, [field.key]: next })}
+                      />
                     </div>
                   ) : (
                     <div key={field.key} className='flex flex-col gap-1'>

--- a/src/components/forms/AdminActionForm.tsx
+++ b/src/components/forms/AdminActionForm.tsx
@@ -8,6 +8,7 @@ import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 
 import TextInput from '../inputs/TextInput'
+import AddressBookInput from '../inputs/AddressBookInput'
 import DurationInput from '../inputs/DurationInput'
 import EthersInput from '../inputs/EthersInput'
 import HexSelectorInput from '../inputs/HexSelectorInput'
@@ -144,6 +145,16 @@ const AdminActionForm: React.FC<AdminActionFormProps> = ({ multiSigAddress }) =>
                         onCheckedChange={(checked) => setValues({ ...values, [field.key]: String(checked) })}
                       />
                       <span className='text-sm text-foreground'>{field.label}</span>
+                    </div>
+                  ) : field.kind === 'address' ? (
+                    <div key={field.key} className='flex flex-col gap-1'>
+                      <span className='text-sm font-semibold text-foreground'>{field.label}</span>
+                      <AddressBookInput
+                        placeholder={field.placeholder ?? `${field.label} address (0x...)`}
+                        allowSave
+                        value={values[field.key] ?? ''}
+                        onChange={(next) => setValues({ ...values, [field.key]: next })}
+                      />
                     </div>
                   ) : field.kind === 'duration' ? (
                     <div key={field.key} className='flex flex-col gap-1'>

--- a/src/components/inputs/DurationInput.stories.tsx
+++ b/src/components/inputs/DurationInput.stories.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import DurationInput from './DurationInput'
+
+const meta: Meta<typeof DurationInput> = {
+  title: 'Inputs/DurationInput',
+  component: DurationInput,
+}
+export default meta
+
+export const Basic: StoryFn<typeof DurationInput> = (args: React.ComponentProps<typeof DurationInput>) => {
+  const [value, setValue] = useState('')
+  return <DurationInput {...args} value={value} onChange={setValue} />
+}
+Basic.args = {
+  helperText: 'How long a sensitive call should wait before it can execute',
+  minSeconds: 7n * 24n * 60n * 60n
+}

--- a/src/components/inputs/DurationInput.tsx
+++ b/src/components/inputs/DurationInput.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+import TextInput from './TextInput'
+
+type Mode = 'friendly' | 'raw'
+
+interface DurationInputProps {
+  // String of seconds (matches the contract's uint256 value): the field shape
+  // every other stage still consumes.
+  value: string
+  onChange: (seconds: string) => void
+  isInvalid?: boolean
+  // If set, the contract's minimum allowed seconds (e.g. the 7-day floor on
+  // ownership delegation). Shown as a friendly hint, not enforced here.
+  minSeconds?: bigint
+  // Prefixed to the helper text under the field.
+  helperText?: string
+  disabled?: boolean
+}
+
+// 1d / 1h / 1m defaults so the timelock + inactivity windows don't open on
+// the unfriendly "0 seconds" value.
+const DEFAULT_FRIENDLY = { days: 1, hours: 0, minutes: 0 }
+
+const splitSeconds = (seconds: bigint): { days: number; hours: number; minutes: number; leftover: number } => {
+  let remaining = seconds
+  const days = remaining / 86400n
+  remaining -= days * 86400n
+  const hours = remaining / 3600n
+  remaining -= hours * 3600n
+  const minutes = remaining / 60n
+  remaining -= minutes * 60n
+  return {
+    days: Number(days),
+    hours: Number(hours),
+    minutes: Number(minutes),
+    leftover: Number(remaining)
+  }
+}
+
+const composeSeconds = (days: number, hours: number, minutes: number): bigint => {
+  const safe = (n: number) => Math.max(0, Math.floor(n))
+  return BigInt(safe(days)) * 86400n + BigInt(safe(hours)) * 3600n + BigInt(safe(minutes)) * 60n
+}
+
+const formatDuration = (seconds: bigint): string => {
+  if (seconds === 0n) return '0 seconds'
+  const { days, hours, minutes } = splitSeconds(seconds)
+  const parts: string[] = []
+  if (days > 0) parts.push(`${days} day${days === 1 ? '' : 's'}`)
+  if (hours > 0) parts.push(`${hours} hour${hours === 1 ? '' : 's'}`)
+  if (minutes > 0) parts.push(`${minutes} minute${minutes === 1 ? '' : 's'}`)
+  return parts.join(' ')
+}
+
+// Friendly duration entry. By default the field collects days/hours/minutes and
+// surfaces the total seconds; an "Advanced (raw seconds)" toggle exposes the
+// raw uint256 so callers comfortable with seconds can paste values directly.
+const DurationInput: React.FC<DurationInputProps> = ({
+  value,
+  onChange,
+  isInvalid,
+  minSeconds,
+  helperText,
+  disabled
+}) => {
+  // Power users may paste raw seconds directly; we keep the mode explicit so a
+  // round-trip doesn't silently unit-convert a non-aligned value.
+  const [mode, setMode] = useState<Mode>('friendly')
+  const [days, setDays] = useState(DEFAULT_FRIENDLY.days)
+  const [hours, setHours] = useState(DEFAULT_FRIENDLY.hours)
+  const [minutes, setMinutes] = useState(DEFAULT_FRIENDLY.minutes)
+
+  const seconds = useMemo(() => {
+    if (value === '' || !/^\d+$/.test(value)) return null
+    try {
+      return BigInt(value)
+    } catch {
+      return null
+    }
+  }, [value])
+
+  const seedFromValue = (raw: string) => {
+    if (!/^\d+$/.test(raw)) return
+    const split = splitSeconds(BigInt(raw))
+    setDays(split.days)
+    setHours(split.hours)
+    setMinutes(split.minutes)
+  }
+
+  // When callers reset the form (admin action re-selection), keep the
+  // friendly sub-fields in sync with the new raw value.
+  useEffect(() => {
+    if (mode === 'friendly' && seconds != null) seedFromValue(value)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
+
+  const apply = (nextDays: number, nextHours: number, nextMinutes: number) => {
+    setDays(nextDays)
+    setHours(nextHours)
+    setMinutes(nextMinutes)
+    onChange(composeSeconds(nextDays, nextHours, nextMinutes).toString())
+  }
+
+  const friendlySummary =
+    seconds == null ? 'Not set yet — defaults to one day once submitted.' : formatDuration(seconds)
+
+  return (
+    <div className='flex w-full flex-col gap-1.5'>
+      {mode === 'friendly' ? (
+        <>
+          <div className='grid grid-cols-3 gap-2'>
+            <div className='flex flex-col gap-1'>
+              <span className='text-xs text-muted-foreground'>Days</span>
+              <Input
+                type='number'
+                inputMode='numeric'
+                min={0}
+                value={days}
+                disabled={disabled}
+                onChange={(e) => apply(Number(e.target.value), hours, minutes)}
+                className={cn('h-auto w-full px-4 py-3 text-base md:w-full md:text-sm', isInvalid && 'border-destructive')}
+              />
+            </div>
+            <div className='flex flex-col gap-1'>
+              <span className='text-xs text-muted-foreground'>Hours</span>
+              <Input
+                type='number'
+                inputMode='numeric'
+                min={0}
+                max={23}
+                value={hours}
+                disabled={disabled}
+                onChange={(e) => apply(days, Number(e.target.value), minutes)}
+                className={cn('h-auto w-full px-4 py-3 text-base md:w-full md:text-sm', isInvalid && 'border-destructive')}
+              />
+            </div>
+            <div className='flex flex-col gap-1'>
+              <span className='text-xs text-muted-foreground'>Minutes</span>
+              <Input
+                type='number'
+                inputMode='numeric'
+                min={0}
+                max={59}
+                value={minutes}
+                disabled={disabled}
+                onChange={(e) => apply(days, hours, Number(e.target.value))}
+                className={cn('h-auto w-full px-4 py-3 text-base md:w-full md:text-sm', isInvalid && 'border-destructive')}
+              />
+            </div>
+          </div>
+          <span className='text-xs text-muted-foreground'>
+            {helperText ? `${helperText} — ` : ''}Total: <span className='font-semibold text-foreground'>{friendlySummary}</span>
+            {minSeconds != null && (
+              <> · minimum required: <span className='font-mono'>{formatDuration(minSeconds)}</span></>
+            )}
+          </span>
+        </>
+      ) : (
+        <>
+          <TextInput
+            className='md:w-full'
+            placeholder='e.g. 86400 (1 day)'
+            value={value}
+            isInvalid={isInvalid}
+            disabled={disabled}
+            onChange={(e) => onChange(e.target.value.trim())}
+          />
+          {seconds != null && (
+            <span className='text-xs text-muted-foreground'>Friendly view: {formatDuration(seconds)}</span>
+          )}
+        </>
+      )}
+      <button
+        type='button'
+        className='self-start text-xs font-medium text-primary hover:underline'
+        onClick={() => {
+          if (mode === 'friendly') {
+            // Going raw: keep the current friendly value as the underlying
+            // seconds string so nothing changes on submit.
+            setMode('raw')
+          } else {
+            seedFromValue(value)
+            setMode('friendly')
+          }
+        }}
+      >
+        {mode === 'friendly' ? 'Advanced (raw seconds)' : 'Back to friendly entry'}
+      </button>
+    </div>
+  )
+}
+
+export default DurationInput

--- a/src/components/inputs/EthersInput.stories.tsx
+++ b/src/components/inputs/EthersInput.stories.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import EthersInput from './EthersInput'
+
+const meta: Meta<typeof EthersInput> = {
+  title: 'Inputs/EthersInput',
+  component: EthersInput,
+}
+export default meta
+
+export const Basic: StoryFn<typeof EthersInput> = (args: React.ComponentProps<typeof EthersInput>) => {
+  const [value, setValue] = useState('')
+  return <EthersInput {...args} value={value} onChange={setValue} />
+}
+Basic.args = {
+  symbol: 'ETH',
+  helperText: 'Daily cap, set to 0 to remove the allowance'
+}

--- a/src/components/inputs/EthersInput.tsx
+++ b/src/components/inputs/EthersInput.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { formatEther, parseEther } from 'viem'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+import TextInput from './TextInput'
+
+type Mode = 'eth' | 'wei'
+
+interface EthersInputProps {
+  // Raw wei as a string — same shape every downstream consumer already
+  // reads (`BigInt(value)` for the contract arg).
+  value: string
+  onChange: (wei: string) => void
+  // ERC-20 tokens: pass decimals here and override the unit label.
+  decimals?: number
+  symbol?: string
+  isInvalid?: boolean
+  helperText?: string
+  // Upper bound shown next to the field as a friendly hint (e.g. the rolling
+  // daily allowance cap). Wired but optional.
+  balanceHint?: bigint
+  disabled?: boolean
+}
+
+const isUint = (value: string) => /^\d+$/.test(value)
+
+// Amount entry that defaults to a decimal native-currency field and keeps a
+// "Wei (raw units)" toggle for power users or amounts below the smallest
+// displayable unit. The string it emits is always the integer wei count so
+// encodeFunctionData() stays unchanged.
+const EthersInput: React.FC<EthersInputProps> = ({
+  value,
+  onChange,
+  decimals = 18,
+  symbol = 'ETH',
+  isInvalid,
+  helperText,
+  balanceHint,
+  disabled
+}) => {
+  const [mode, setMode] = useState<Mode>('eth')
+  const [decimal, setDecimal] = useState('')
+
+  const wei = useMemo(() => {
+    if (value === '' || !isUint(value)) return null
+    try {
+      return BigInt(value)
+    } catch {
+      return null
+    }
+  }, [value])
+
+  const formatDecimal = (rawWei: bigint): string => {
+    try {
+      // viem is fine with fractional ether up to the token's decimals; we
+      // trim trailing zeros so 1.0 ETH doesn't print as "1.0000".
+      const formatted = formatEther(rawWei)
+      return formatted.includes('.') ? formatted.replace(/\.?0+$/, '') : formatted
+    } catch {
+      return ''
+    }
+  }
+
+  // When the upstream value changes (e.g. action re-selection), reflect the
+  // new decimal value in the input.
+  useEffect(() => {
+    if (mode === 'eth') setDecimal(wei == null ? '' : formatDecimal(wei))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
+
+  const commitDecimal = (next: string) => {
+    setDecimal(next)
+    if (next.trim() === '') {
+      onChange('')
+      return
+    }
+    try {
+      const parsed = parseEther(next)
+      onChange(parsed.toString())
+    } catch {
+      // Invalid decimal — let validation in the parent surface the error.
+    }
+  }
+
+  // Friendly preview of an integer wei value, useful for non-18-decimal tokens.
+  const previewFriendly = (rawWei: bigint): string => {
+    if (decimals === 18) return formatEther(rawWei)
+    const negative = rawWei < 0n
+    let raw = negative ? -rawWei : rawWei
+    const base = 10n ** BigInt(decimals)
+    const whole = raw / base
+    const fraction = (raw % base).toString().padStart(decimals, '0').replace(/0+$/, '')
+    const wholeStr = whole.toLocaleString()
+    return `${negative ? '-' : ''}${wholeStr}${fraction ? `.${fraction}` : ''}`
+  }
+
+  return (
+    <div className='flex w-full flex-col gap-1.5'>
+      {mode === 'eth' ? (
+        <>
+          <div className='flex w-full items-center gap-2'>
+            <Input
+              inputMode='decimal'
+              placeholder={`Amount in ${symbol}`}
+              value={decimal}
+              disabled={disabled}
+              onChange={(e) => commitDecimal(e.target.value.trim())}
+              className={cn(
+                'h-auto w-full px-4 py-3 text-base md:w-full md:text-sm',
+                isInvalid && 'border-destructive focus-visible:ring-destructive'
+              )}
+            />
+            {balanceHint != null && (
+              <Button
+                type='button'
+                variant='outline'
+                size='sm'
+                disabled={disabled}
+                onClick={() => commitDecimal(previewFriendly(balanceHint))}
+              >
+                Max
+              </Button>
+            )}
+          </div>
+          <span className='text-xs text-muted-foreground'>
+            {helperText ? `${helperText} — ` : ''}
+            {wei != null ? (
+              <>
+                Wei value: <span className='font-mono text-foreground'>{wei.toString()}</span>
+              </>
+            ) : (
+              <>Enter a {symbol} amount — convert to wei on submit.</>
+            )}
+          </span>
+        </>
+      ) : (
+        <>
+          <TextInput
+            className='font-mono md:w-full'
+            placeholder='Wei (integer)'
+            value={value}
+            isInvalid={isInvalid}
+            disabled={disabled}
+            onChange={(e) => onChange(e.target.value.trim())}
+          />
+          {wei != null && (
+            <span className='text-xs text-muted-foreground'>
+              Friendly view: {previewFriendly(wei)} {symbol}
+            </span>
+          )}
+        </>
+      )}
+      <button
+        type='button'
+        className='self-start text-xs font-medium text-primary hover:underline'
+        onClick={() => {
+          if (mode === 'eth') {
+            setMode('wei')
+          } else {
+            if (wei != null) setDecimal(formatDecimal(wei))
+            setMode('eth')
+          }
+        }}
+      >
+        {mode === 'eth' ? `Advanced (raw ${decimals === 18 ? 'wei' : 'units'})` : 'Back to friendly entry'}
+      </button>
+    </div>
+  )
+}
+
+export default EthersInput

--- a/src/components/inputs/HexSelectorInput.stories.tsx
+++ b/src/components/inputs/HexSelectorInput.stories.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+import type { Abi } from 'viem'
+import MyMultiSig from 'mymultisig-contract/abi/MyMultiSig.json'
+
+import HexSelectorInput from './HexSelectorInput'
+
+const meta: Meta<typeof HexSelectorInput> = {
+  title: 'Inputs/HexSelectorInput',
+  component: HexSelectorInput,
+}
+export default meta
+
+export const Basic: StoryFn<typeof HexSelectorInput> = (args: React.ComponentProps<typeof HexSelectorInput>) => {
+  const [value, setValue] = useState('')
+  return <HexSelectorInput {...args} value={value} onChange={setValue} />
+}
+Basic.args = {
+  abis: [MyMultiSig as Abi],
+  helperText: 'The wallet pre-registers its own admin selectors at deployment'
+}

--- a/src/components/inputs/HexSelectorInput.tsx
+++ b/src/components/inputs/HexSelectorInput.tsx
@@ -1,0 +1,161 @@
+import React, { useMemo, useState } from 'react'
+import { Abi, toFunctionSelector } from 'viem'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+
+import TextInput from './TextInput'
+
+interface KnownSelector {
+  selector: `0x${string}`
+  label: string
+  hint: string
+}
+
+interface HexSelectorInputProps {
+  // 4-byte function selector (0x + 8 hex chars). Empty string clears.
+  value: string
+  onChange: (selector: string) => void
+  // Wallet ABIs we want to recognise by name so the dropdown can show a
+  // readable label rather than ask users to paste a hash.
+  abis: Abi[]
+  // Optional set of hex selectors to surface pre-registered.
+  extra?: KnownSelector[]
+  isInvalid?: boolean
+  helperText?: string
+  disabled?: boolean
+}
+
+const isBytes4 = (value: string) => /^0x[a-fA-F0-9]{8}$/.test(value)
+
+const CUSTOM_VALUE = '__custom__'
+
+// Friendly hex selector entry. Recognises the wallet's own writeable admin
+// selectors (and any extras the caller hands in) via a dropdown; "Custom…"
+// falls back to a raw 4-byte input so power users can paste any hash.
+const HexSelectorInput: React.FC<HexSelectorInputProps> = ({
+  value,
+  onChange,
+  abis,
+  extra,
+  isInvalid,
+  helperText,
+  disabled
+}) => {
+  // Build the dropdown entries once per ABI change. Same selector showing up
+  // under multiple names keeps the first label; the hint tells the user what
+  // the wallet would do if it executed the call.
+  const knownSelectors = useMemo<KnownSelector[]>(() => {
+    const seen = new Map<string, KnownSelector>()
+    const consider = (name: string, hash: `0x${string}`, hint: string) => {
+      if (!isBytes4(hash)) return
+      const key = hash.toLowerCase()
+      if (!seen.has(key)) seen.set(key, { selector: hash, label: name, hint })
+    }
+    for (const abi of abis) {
+      for (const item of abi as readonly unknown[]) {
+        // Only callable, non-view entries make sense in the timelock-sensitive
+        // context this dropdown feeds.
+        const fn = item as { type?: string; name?: string; stateMutability?: string }
+        if (fn?.type !== 'function' || !fn.name) continue
+        if (fn.stateMutability === 'view' || fn.stateMutability === 'pure') continue
+        try {
+          const selector = toFunctionSelector(fn as never) as `0x${string}`
+          consider(fn.name, selector, `Signature: ${fn.name}`)
+        } catch {
+          // Skip fragments viem can't encode (e.g. tuples in the args).
+        }
+      }
+    }
+    if (extra != null) {
+      for (const entry of extra) {
+        const key = entry.selector.toLowerCase()
+        if (!seen.has(key)) seen.set(key, entry)
+      }
+    }
+    return Array.from(seen.values()).sort((a, b) => a.label.localeCompare(b.label))
+  }, [abis, extra])
+
+  // Decide which option matches the current raw value.
+  const matched = useMemo(() => knownSelectors.find((k) => k.selector.toLowerCase() === (value ?? '').toLowerCase()), [
+    knownSelectors,
+    value
+  ])
+
+  const [customOpen, setCustomOpen] = useState(false)
+  const showCustom = !isBytes4(value)
+
+  const handleSelect = (next: string) => {
+    if (next === CUSTOM_VALUE) {
+      setCustomOpen(true)
+      return
+    }
+    setCustomOpen(false)
+    onChange(next)
+  }
+
+  return (
+    <div className='flex w-full flex-col gap-1.5'>
+      {!customOpen && !showCustom ? (
+        <Select value={matched?.selector ?? ''} onValueChange={handleSelect} disabled={disabled}>
+          <SelectTrigger className='w-full'>
+            <SelectValue placeholder='Pick a wallet function'>
+              {matched ? matched.label : 'Pick a wallet function'}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {knownSelectors.map((entry) => (
+              <SelectItem key={entry.selector} value={entry.selector}>
+                <span className='flex flex-col'>
+                  <span>{entry.label}</span>
+                  <span className='font-mono text-[10px] text-muted-foreground'>{entry.selector}</span>
+                </span>
+              </SelectItem>
+            ))}
+            <SelectItem value={CUSTOM_VALUE}>Custom 4-byte selector…</SelectItem>
+          </SelectContent>
+        </Select>
+      ) : (
+        <TextInput
+          className='font-mono md:w-full'
+          placeholder='0x7065cb48'
+          value={value}
+          isInvalid={isInvalid}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value.trim())}
+        />
+      )}
+
+      <div className='flex flex-wrap items-center gap-2'>
+        <span
+          className={cn(
+            'rounded px-2 py-0.5 font-mono text-xs',
+            isBytes4(value) ? 'bg-muted text-foreground' : 'text-muted-foreground'
+          )}
+        >
+          {isBytes4(value) ? value : 'no selector yet'}
+        </span>
+        {matched != null && (
+          <span className='text-xs text-muted-foreground'>— {matched.hint}</span>
+        )}
+        {helperText != null && <span className='text-xs text-muted-foreground'>{helperText}</span>}
+      </div>
+
+      <button
+        type='button'
+        className='self-start text-xs font-medium text-primary hover:underline'
+        onClick={() => setCustomOpen((open) => !open)}
+      >
+        {customOpen || showCustom ? 'Pick from the wallet functions' : 'Enter a hex selector manually'}
+      </button>
+    </div>
+  )
+}
+
+export default HexSelectorInput
+export type { KnownSelector }

--- a/src/utils/adminActions.ts
+++ b/src/utils/adminActions.ts
@@ -10,13 +10,31 @@ import { gteVersion } from './contractVersions'
 
 const abi = MyMultiSigExtended as Abi
 
-export type AdminFieldKind = 'address' | 'number' | 'boolean' | 'seconds' | 'bytes4' | 'wei'
+// 'duration' / 'ethers' / 'selector' are friendly variants of the raw
+// 'seconds' / 'wei' / 'bytes4' inputs — the AdminActionForm renders them as
+// human-friendly widgets (days/hours/minutes, ETH, named function dropdown)
+// and keeps a "raw units" toggle so power users still get the granular value.
+// Downstream validation/buildArgs continue to receive the raw string (seconds,
+// wei, 0x…), so the contract arg path is untouched.
+export type AdminFieldKind =
+  | 'address'
+  | 'number'
+  | 'boolean'
+  | 'seconds'
+  | 'bytes4'
+  | 'wei'
+  | 'duration'
+  | 'ethers'
+  | 'selector'
 
 export type AdminField = {
   key: string
   label: string
   placeholder?: string
   kind: AdminFieldKind
+  // For the duration family: a non-binding display of the contract minimum
+  // (e.g. 7-day floor for inactivity delegation); surfaced as friendly text.
+  minSeconds?: bigint
 }
 
 export type AdminActionGroup =
@@ -190,7 +208,12 @@ export const ADMIN_ACTIONS: AdminActionDefinition[] = [
     availableOn: 'extended',
     hint: 'Sets the minimum inactivity period (at least 7 days) before a delegatee can take over an owner seat.',
     fields: [
-      { key: 'seconds', label: 'Inactivity window (seconds)', placeholder: 'e.g. 604800 (7 days)', kind: 'seconds' }
+      {
+        key: 'seconds',
+        label: 'Inactivity window',
+        kind: 'duration',
+        minSeconds: 7n * 24n * 60n * 60n
+      }
     ],
     describe: (v) => `Set minimum inactivity window to ${v.seconds} seconds`,
     buildArgs: (v) => [BigInt(v.seconds)],
@@ -210,9 +233,8 @@ export const ADMIN_ACTIONS: AdminActionDefinition[] = [
       { key: 'owner', label: 'Owner', placeholder: 'Owner address (0x...)', kind: 'address' },
       {
         key: 'seconds',
-        label: 'Inactivity window (seconds)',
-        placeholder: 'Must exceed the wallet minimum',
-        kind: 'seconds'
+        label: 'Inactivity window',
+        kind: 'duration'
       },
       { key: 'delegatee', label: 'Delegatee', placeholder: 'Delegatee address (0x...)', kind: 'address' }
     ],
@@ -232,7 +254,7 @@ export const ADMIN_ACTIONS: AdminActionDefinition[] = [
     availableOn: 'extended',
     minWalletVersion: '0.5.0',
     hint: 'Sensitive calls (privileged self-calls, transfers above the wei threshold) must then be scheduled and wait out this delay before executing. Set 0 to turn the timelock off.',
-    fields: [{ key: 'seconds', label: 'Delay (seconds)', placeholder: 'e.g. 86400 (1 day)', kind: 'seconds' }],
+    fields: [{ key: 'seconds', label: 'Delay before sensitive calls execute', kind: 'duration' }],
     describe: (v) =>
       v.seconds === '0' ? 'Disable the timelock' : `Set the timelock delay to ${v.seconds} seconds`,
     buildArgs: (v) => [BigInt(v.seconds)],
@@ -246,7 +268,7 @@ export const ADMIN_ACTIONS: AdminActionDefinition[] = [
     minWalletVersion: '0.5.0',
     hint: 'Registers (or clears) a 4-byte function selector as sensitive when called on the wallet itself. The wallet pre-registers its own admin selectors at deployment.',
     fields: [
-      { key: 'selector', label: 'Function selector', placeholder: 'e.g. 0x7065cb48 (addOwner)', kind: 'bytes4' },
+      { key: 'selector', label: 'Function on this wallet to gate', kind: 'selector' },
       { key: 'sensitive', label: 'Treat as sensitive', kind: 'boolean' }
     ],
     describe: (v) => `${v.sensitive === 'true' ? 'Mark' : 'Unmark'} selector ${v.selector} as sensitive`,
@@ -260,7 +282,9 @@ export const ADMIN_ACTIONS: AdminActionDefinition[] = [
     availableOn: 'extended',
     minWalletVersion: '0.5.0',
     hint: 'Any transaction moving at least this many wei counts as sensitive and must go through the timelock. Set 0 to disable value-based sensitivity.',
-    fields: [{ key: 'wei', label: 'Threshold (wei)', placeholder: 'e.g. 1000000000000000000 (1 ETH)', kind: 'wei' }],
+    fields: [
+      { key: 'wei', label: 'Transfers of this size or larger are sensitive', kind: 'ethers' }
+    ],
     describe: (v) =>
       v.wei === '0' ? 'Disable the sensitive-value threshold' : `Treat transfers of ${v.wei} wei or more as sensitive`,
     buildArgs: (v) => [BigInt(v.wei)],
@@ -320,7 +344,7 @@ export const ADMIN_ACTIONS: AdminActionDefinition[] = [
     hint: 'Lets this owner spend up to the cap per rolling 24h window with just their own signature (no threshold). Set 0 to remove the allowance.',
     fields: [
       { key: 'owner', label: 'Owner', placeholder: 'Owner address (0x...)', kind: 'address' },
-      { key: 'wei', label: 'Daily cap (wei)', placeholder: 'e.g. 1000000000000000000 (1 ETH)', kind: 'wei' }
+      { key: 'wei', label: 'Daily cap', kind: 'ethers' }
     ],
     describe: (v) =>
       v.wei === '0'


### PR DESCRIPTION
## Summary

The wallet settings page demanded raw on-chain units for several common actions (timelock delay in seconds, sensitive selector as a bare 4-byte hash, value thresholds and daily spending caps in wei, inactivity windows in seconds) and used bare text fields for owner / delegatee / guard / module / target addresses. Casual users had to convert units by hand and paste raw hex; only power users comfortable with the units and the address book alone got a sensible experience.

This change keeps the raw values (and a power-user "Advanced" toggle for them) and adds a friendly first-class entry on top:

- **`DurationInput`** — *Days / Hours / Minutes* triple with a live "Total: 1 day" read-out; reports the raw seconds string on submit. Used for timelock delay, wallet inactivity window, per-owner inactivity window.
- **`EthersInput`** — decimal native-currency entry (resolved wei shown underneath); "Advanced" toggle exposes the raw wei. Used for sensitive-value threshold, daily spending cap.
- **`HexSelectorInput`** — reads the wallet's own ABIs (`MyMultiSig` + `MyMultiSigExtended`) and offers recognised admin functions as a named dropdown (`addOwner`, `removeOwner`, `changeThreshold`, `setGuard`, …). "Custom 4-byte selector" toggle falls back to the original hex input. Used for the "Mark a selector sensitive" action.
- **`AddressBookInput` for owner / module / guard / target addresses** — the admin-form `kind: 'address'` branch now renders the same combobox used on the build-request form (saved-address dropdown, label resolution, "Save to address book" affordance), so adding/removing owners, picking a delegatee, setting a guard, enabling a module, etc. all behave consistently.

The downstream contract-arg pipeline is **unchanged** — every friendly input still emits the raw string the existing `validate`, `buildArgs`, and `encodeAdminAction` already accept, so no contract call path needed to learn about the new widgets.

## Files

- `src/components/inputs/DurationInput.tsx` + `.stories.tsx` (new)
- `src/components/inputs/EthersInput.tsx` + `.stories.tsx` (new)
- `src/components/inputs/HexSelectorInput.tsx` + `.stories.tsx` (new)
- `src/utils/adminActions.ts` — adds `'duration' | 'ethers' | 'selector'` to `AdminFieldKind` and switches the relevant settings actions to those kinds. Adds a non-binding `minSeconds` hint on `AdminField` (used for the 7-day inactivity floor).
- `src/components/forms/AdminActionForm.tsx` — dispatches per-field on the new kinds to render the friendly inputs; renders the existing `AddressBookInput` for `kind: 'address'`.

## Verification

- `yarn eslint` clean on every touched file.
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)