### PR TITLE
fix(wallet-type): stop mislabeling Extended wallets as Simple on refresh

### DIFF
--- a/src/hooks/useWalletType.ts
+++ b/src/hooks/useWalletType.ts
@@ -1,32 +1,96 @@
-import { useChainId, useChains, useReadContract } from 'wagmi'
+import { useEffect } from 'react'
+import { useChainId, useChains, useReadContracts } from 'wagmi'
+import type { Abi } from 'viem'
+import MyMultiSig from 'mymultisig-contract/abi/MyMultiSig.json'
 import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
 
 import { WalletType } from '../models/MultiSigs'
+import useMultiSigs from '../states/multiSigs'
 
 // Detects whether a deployed wallet is a MyMultiSig or MyMultiSigExtended by
-// probing allowOnlyOwnerRequest(), which only exists on the Extended variant.
-// A revert means the wallet is a simple MyMultiSig.
+// probing two functions in a single multicall:
+//   1. version() — works on BOTH variants, so a revert here means the address
+//      isn't a wallet at all (a real RPC error, not a "simple wallet")
+//   2. allowOnlyOwnerRequest() — only on the Extended variant; a revert here
+//      is the "this is a simple wallet" signal
+//
+// Pre-fix this hook relied on a single useReadContract with retry:false, so any
+// transient RPC failure during a page refresh would lock the wallet in as
+// 'simple' for the rest of the session and hide every Extended-only panel
+// until the user refreshed again. Now we wait for both probes to settle, retry
+// a couple times on cold-start RPC flakiness, and fall back to the walletType
+// already persisted in the multiSigs store (set by ImportConfirmationCard or a
+// prior live detection). A confident live detection also writes back into the
+// store so a refresh later (or another tab) starts from the right answer.
 const useWalletType = (multiSigAddress: `0x${string}`) => {
   const chainId = useChainId()
   const chains = useChains()
   const chain = chains.find((c) => c.id === chainId)
-  const { data, isError, isFetched } = useReadContract({
-    chainId: chain?.id,
-    address: multiSigAddress,
-    abi: MyMultiSigExtended,
-    functionName: 'allowOnlyOwnerRequest',
+  const { multiSigs, updateMultiSig } = useMultiSigs()
+  const stored = multiSigs.find((m) => m.address.toLowerCase() === multiSigAddress.toLowerCase())
+  const storedType = stored?.walletType
+
+  const { data } = useReadContracts({
+    contracts: [
+      {
+        chainId: chain?.id,
+        address: multiSigAddress,
+        abi: MyMultiSig as Abi,
+        functionName: 'version'
+      },
+      {
+        chainId: chain?.id,
+        address: multiSigAddress,
+        abi: MyMultiSigExtended as Abi,
+        functionName: 'allowOnlyOwnerRequest'
+      }
+    ],
+    allowFailure: true,
     query: {
       enabled: multiSigAddress !== '0x',
-      retry: false
+      // Tolerate a couple of cold-start RPC failures before we commit a verdict;
+      // a transient error must not flip the wallet to 'simple'.
+      retry: 2,
+      retryDelay: 800,
+      staleTime: 30_000
     }
   })
 
-  const walletType: WalletType | undefined = isFetched ? (isError ? 'simple' : 'extended') : undefined
+  const versionProbe = data?.[0]
+  const extendedProbe = data?.[1]
+
+  const settled =
+    versionProbe != null &&
+    (versionProbe.status === 'success' || versionProbe.status === 'failure') &&
+    extendedProbe != null &&
+    (extendedProbe.status === 'success' || extendedProbe.status === 'failure')
+
+  const liveType: WalletType | undefined = (() => {
+    if (!settled) return undefined
+    if (versionProbe.status === 'failure') return undefined
+    return extendedProbe.status === 'success' ? 'extended' : 'simple'
+  })()
+
+  // Mirror a confident live detection into the store so the next page load
+  // doesn't re-run the race that triggered this bug. Skipped when the stored
+  // value already matches to avoid an extra re-render.
+  useEffect(() => {
+    if (liveType != null && liveType !== storedType) {
+      updateMultiSig(multiSigAddress, { walletType: liveType })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [liveType, storedType, multiSigAddress])
+
+  // Authoritative answer: prefer a confident live read, otherwise surface the
+  // persisted value (undefined when nothing is known yet). Treating "uncertain"
+  // as "extended" would create a new bug when the contract really is simple,
+  // so consumers gate on isFetched when they need a strict verdict.
+  const walletType: WalletType | undefined = liveType ?? storedType
 
   return {
     walletType,
-    allowOnlyOwnerRequest: walletType === 'extended' ? Boolean(data) : false,
-    isFetched
+    allowOnlyOwnerRequest: walletType === 'extended' ? Boolean(extendedProbe?.result) : false,
+    isFetched: settled
   }
 }
 


### PR DESCRIPTION
## Bug

Refreshing the wallet settings page often showed the multisig as `'Simple'`, hiding the Extended-only panels (governance, advanced features, modules, spending allowances, account abstraction, scheduled execution, the delegate-call toggle on the build-request form) and the `'Extended'` badge in the page header. The next refresh usually came back correct.

## Root cause

`src/hooks/useWalletType.ts` ran a **single** `useReadContract` probe for `allowOnlyOwnerRequest()` with `retry: false`. Any transient RPC failure during a cold start (network blip, chain-id settling, RPC rate-limit) reverted that one call and the hook immediately locked the wallet in as `'simple'` for the rest of the session — and there was no fallback to the `walletType` already persisted in the `multiSigs` Zustand store (imported by `ImportConfirmationCard`), so every refresh re-ran the race from scratch.

## Fix

`useWalletType` now multicalls two probes in a single round trip:

1. `version()` — works on **both** wallet variants, so a revert here means the address isn't a wallet at all (a real RPC problem), not "this is a simple wallet."
2. `allowOnlyOwnerRequest()` — only on the Extended variant; a revert here is the genuine "this is a simple wallet" signal.

Together the combination tells us authoritatively:

| `version()` | `allowOnlyOwnerRequest()` | Verdict |
|---|---|---|
| success     | success                   | extended |
| success     | revert                    | simple   |
| revert      | revert                    | not a wallet (returns `undefined`) |

Other changes:

- `query.retry: 2` with `retryDelay: 800` so a transient RPC error no longer decides the verdict on the first attempt.
- `query.staleTime: 30_000` so quick successive renders don't refetch the chain.
- `walletType` stays `undefined` while the probes are still pending. Consumers that gate on `isFetched` (`useExecTransaction`, `useSignedMultiSigRequest`, `useRequestApprovalState`) keep waiting, so execution doesn't fire with the wrong overload.
- While the live read is in flight, the hook falls back to `stored.walletType` (already persisted by `ImportConfirmationCard` and prior detections).
- A confident live verdict is mirrored back into the `multiSigs` store via `updateMultiSig` so the next page load — and other tabs — start from the right answer instead of re-running the race.

## Files

- `src/hooks/useWalletType.ts` (only file touched)

## Verification

- `yarn eslint` clean.
- `npx tsc --noEmit` clean.
- No consumer-facing API change (`{ walletType, allowOnlyOwnerRequest, isFetched }` shape preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)