### PR TITLE
feat(aa): ERC-4337 UserOp path (build / sign / send-to-bundler)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,14 @@ NEXT_PUBLIC_ALCHEMY_API_KEY=
 NEXT_PUBLIC_INFURA_API_KEY=
 NEXT_PUBLIC_APP_GTAG=
 
+# ERC-4337 bundler + paymaster URLs (per-chain override or global fallback).
+# Per-chain wins; the global fallback is used when no per-chain URL is set.
+# Examples:
+#   NEXT_PUBLIC_BUNDLER_URL_11155111=https://api.pimlico.io/v2/sepolia/rpc?api-key=YOUR_KEY
+#   NEXT_PUBLIC_PAYMASTER_URL_11155111=https://api.pimlico.io/v2/sepolia/rpc?api-key=YOUR_KEY
+NEXT_PUBLIC_BUNDLER_URL=
+NEXT_PUBLIC_PAYMASTER_URL=
+
 # Server-only variables
 DATABASE_URL=
 ETHERSCAN_API_KEY=

--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,14 @@ RPC_ETHEREUM=""
 # WalletConnect Project ID
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=""
 
+# ERC-4337 bundler + paymaster URLs (per-chain override or global fallback).
+# Per-chain wins; the global fallback is used when no per-chain URL is set.
+# Examples:
+#   NEXT_PUBLIC_BUNDLER_URL_11155111=https://api.pimlico.io/v2/sepolia/rpc?api-key=YOUR_KEY
+#   NEXT_PUBLIC_PAYMASTER_URL_11155111=https://api.pimlico.io/v2/sepolia/rpc?api-key=YOUR_KEY
+NEXT_PUBLIC_BUNDLER_URL=""
+NEXT_PUBLIC_PAYMASTER_URL=""
+
 # Neon PostgreSQL
 DATABASE_URL="postgresql://[user]:[password]@[host]/[dbname]?sslmode=require"
 

--- a/docs/PRD-contract-feature-parity.md
+++ b/docs/PRD-contract-feature-parity.md
@@ -1,12 +1,12 @@
 # PRD: Full Smart-Contract Feature Parity in mymultisig.app
 
-| Field | Value |
-| --- | --- |
-| Product | mymultisig-app |
-| Contract source of truth | [marc-aurele-besner/mymultisig-contract](https://github.com/marc-aurele-besner/mymultisig-contract) `main` |
-| App package today | `mymultisig-contract@0.1.0` (ABI lagging behind GitHub) |
-| Goal | Expose every user-facing capability of `MyMultiSig`, `MyMultiSigExtended`, and `MyMultiSigFactory` in the web app |
-| Non-goal | Rebuilding the contracts; Slack/Discord bots; Safe connector UX |
+| Field                    | Value                                                                                                             |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| Product                  | mymultisig-app                                                                                                    |
+| Contract source of truth | [marc-aurele-besner/mymultisig-contract](https://github.com/marc-aurele-besner/mymultisig-contract) `main`        |
+| App package today        | `mymultisig-contract@0.1.0` (ABI lagging behind GitHub)                                                           |
+| Goal                     | Expose every user-facing capability of `MyMultiSig`, `MyMultiSigExtended`, and `MyMultiSigFactory` in the web app |
+| Non-goal                 | Rebuilding the contracts; Slack/Discord bots; Safe connector UX                                                   |
 
 ## 1. Problem
 
@@ -22,20 +22,20 @@ Until the app ships these, contract features exist but are effectively unused.
 
 ## 2. Current state (gap summary)
 
-| Area | Contract | App today |
-| --- | --- | --- |
-| Create simple multisig | `createMultiSig` | Supported |
-| Create extended multisig | `createMyMultiSigExtended` | Not supported |
-| Factory bookkeeping | `multiSig*`, `creationType` | Hook unused / no UI |
-| Sign (EIP-712) | Off-chain | Supported |
-| On-chain approve | `approveHash` | Not supported |
-| Execute | `execTransaction` | Supported (simple signature) |
-| Execute w/ explicit nonce | Extended overload | Not supported |
-| Admin (owners/threshold) | `add/remove/replaceOwner`, `changeThreshold` | Indirect only |
-| Batch | `multiRequest` + results event | Indirect only; no results UI |
-| Extended governance | Delegation, takeover, nonce burn, owner-only requests | Not supported |
-| Preflight | `generateHash`, `isValidSignature` | Not used |
-| Events | incl. `ApproveHash`, `MultiRequestExecuted`, `TxFailure` | Partial (`TransactionExecuted`/`Failed`; EOL log-only) |
+| Area                      | Contract                                                 | App today                                              |
+| ------------------------- | -------------------------------------------------------- | ------------------------------------------------------ |
+| Create simple multisig    | `createMultiSig`                                         | Supported                                              |
+| Create extended multisig  | `createMyMultiSigExtended`                               | Not supported                                          |
+| Factory bookkeeping       | `multiSig*`, `creationType`                              | Hook unused / no UI                                    |
+| Sign (EIP-712)            | Off-chain                                                | Supported                                              |
+| On-chain approve          | `approveHash`                                            | Not supported                                          |
+| Execute                   | `execTransaction`                                        | Supported (simple signature)                           |
+| Execute w/ explicit nonce | Extended overload                                        | Not supported                                          |
+| Admin (owners/threshold)  | `add/remove/replaceOwner`, `changeThreshold`             | Indirect only                                          |
+| Batch                     | `multiRequest` + results event                           | Indirect only; no results UI                           |
+| Extended governance       | Delegation, takeover, nonce burn, owner-only requests    | Not supported                                          |
+| Preflight                 | `generateHash`, `isValidSignature`                       | Not used                                               |
+| Events                    | incl. `ApproveHash`, `MultiRequestExecuted`, `TxFailure` | Partial (`TransactionExecuted`/`Failed`; EOL log-only) |
 
 ## 3. Prerequisites (blocking)
 
@@ -144,13 +144,13 @@ Recent contract changes the app must absorb:
 
 Today these require building a self-call request. Ship first-class flows that still go through the normal sign → execute pipeline (they must be multisig txs).
 
-| Feature | Contract | UX |
-| --- | --- | --- |
-| Add owner | `addOwner` | Form + confirmation of new threshold implications |
-| Remove owner | `removeOwner` | Block if would break threshold |
-| Replace owner | `replaceOwner` | Old → new |
-| Change threshold | `changeThreshold` | Validate 1 ≤ threshold ≤ ownerCount |
-| Skip / bump nonce | `incrementNonce` | Danger zone: invalidate pending requests at old nonce |
+| Feature           | Contract          | UX                                                    |
+| ----------------- | ----------------- | ----------------------------------------------------- |
+| Add owner         | `addOwner`        | Form + confirmation of new threshold implications     |
+| Remove owner      | `removeOwner`     | Block if would break threshold                        |
+| Replace owner     | `replaceOwner`    | Old → new                                             |
+| Change threshold  | `changeThreshold` | Validate 1 ≤ threshold ≤ ownerCount                   |
+| Skip / bump nonce | `incrementNonce`  | Danger zone: invalidate pending requests at old nonce |
 
 Also:
 
@@ -266,21 +266,24 @@ Create flow: Simple | Extended tabs/toggle on create page.
 - `signatures: …` (existing)
 - `txnNonce` (especially Extended)
 - `batchSteps?` + `batchResults?` after execute
+- `mode?: 'standard' | 'userop'` (ERC-4337 path; standard requests stay implicit)
+- `userOpHash?`, `userOpSigningHash?`, `userOpJson?`, `userOpReceipt?` (live PackedUserOperation + receipt when the request is dispatched through a bundler)
+- `bundlerUrl?`, `paymasterUrl?` (captured per request so a second owner can verify the same target)
 
 ## 7. Phased delivery
 
-| Phase | Scope | Outcome |
-| --- | --- | --- |
-| 0 | Package bump, wallet-type detection, owner sync, event rename, factory deployers | App speaks current contract |
-| 1 | Extended create + factory discovery + admin settings UI + ETH sign fix | Parity on create/admin |
-| 2 | `approveHash` hybrid approval + preflight `isValidSignature` | Safe-style UX |
-| 3 | `multiRequest` builder + results | Batch payroll / distributions |
-| 4 | Extended: policy, nonce burn, explicit nonce, takeover, EOL UX | Full Extended surface |
-| 5 | Multi-chain factories, better verify, error decoding | Production hardening |
+| Phase | Scope                                                                            | Outcome                       |
+| ----- | -------------------------------------------------------------------------------- | ----------------------------- |
+| 0     | Package bump, wallet-type detection, owner sync, event rename, factory deployers | App speaks current contract   |
+| 1     | Extended create + factory discovery + admin settings UI + ETH sign fix           | Parity on create/admin        |
+| 2     | `approveHash` hybrid approval + preflight `isValidSignature`                     | Safe-style UX                 |
+| 3     | `multiRequest` builder + results                                                 | Batch payroll / distributions |
+| 4     | Extended: policy, nonce burn, explicit nonce, takeover, EOL UX                   | Full Extended surface         |
+| 5     | Multi-chain factories, better verify, error decoding                             | Production hardening          |
+| 6     | ERC-4337 UserOp path: build, sign, send-to-bundler, paymaster                   | Account-abstraction parity    |
 
 ## 8. Out of scope (for this PRD)
 
-- ChugSplash-specific factory path as primary UX
 - Replacing Neon off-chain requests entirely with on-chain-only approvals (hybrid is the target)
 - Automatic owner enumeration without events/DB (impossible on-chain today)
 - Smart-contract audits / redeploy strategy (ops decision; app should support both old Goerli factory and new addresses)
@@ -292,6 +295,7 @@ Create flow: Simple | Extended tabs/toggle on create page.
 - ≥ 1 successful hybrid execute (`approveHash` + ECDSA) in staging
 - Batch request shows correct per-leg success/fail in UI
 - Zero reliance on outdated 0.1.0 ABI in production
+- ≥ 1 successful UserOp end-to-end (off-chain signature + bundler receipt) in staging on Sepolia
 
 ## 10. Open decisions
 
@@ -299,3 +303,62 @@ Create flow: Simple | Extended tabs/toggle on create page.
 - **Approval default**: keep off-chain-first, or push `approveHash` as primary for hardware wallets?
 - **Redeploy**: keep supporting old Goerli factory version, or migrate users to a new factory version?
 - **Package**: publish npm from GitHub `main` before Phase 0, or pin app to git dependency temporarily?
+
+## 11. Account Abstraction (ERC-4337) — Epic G
+
+The 0.5.0 Extended wallet is a real ERC-4337 v0.7 IAccount: it exposes `validateUserOp`, `userOpSigningHash`, and an EntryPoint-only `execute(to, value, data)`. The wallet's transaction nonce is **not** used on this path — replay protection lives in the EntryPoint's 2D nonce. The owner signature format is the same `(owner, sig)[]` blob the classic `execTransaction` consumes, but the digest is `userOpSigningHash(userOpHash)` (= `EIP191(userOpHash)`) instead of an EIP-712 transaction hash.
+
+**G1. Build**
+
+- UserOp builder: packs `accountGasLimits` and `gasFees` into the two bytes32 fields and fills `callData = wallet.execute(to, value, data)`.
+- Default gas fields are conservative Sepolia-friendly values; the bundler's `eth_estimateUserOperationGas` refines them at submit time.
+- EntryPoint nonce is read from `getNonce(sender, 192)` and refreshed on the bundler receipt.
+
+**G2. Sign (off-chain ECDSA)**
+
+- Toggle on the build-request form: "Submit via bundler (ERC-4337)".
+- When enabled, the EIP-712-only fields (validUntil, operation, pinned nonce, batch) are hidden and the callData is bound to `execute(to, value, data)` instead of `multiRequest` / `execTransaction`.
+- Each owner signs the *inner* `userOpHash` via `personal_sign`; the signature is over `EIP191(userOpHash) = userOpSigningHash`, which is what `_checkSignatures` recovers from in `validateUserOp`.
+- Votes accumulate in the request's `signatures` / `ownerSigners` arrays using the same `(owner, sig)[]` packed encoding the classic path uses.
+
+**G3. Approve on-chain**
+
+- Owners can call `wallet.approveHash(userOpSigningHash(userOpHash))` to count toward the threshold without producing an off-chain signature. Idempotent per (owner, hash).
+- The detail view reads `getApprovedOwners(userOpSigningHash)` and counts it alongside off-chain ECDSA signatures (the contract prevents double votes).
+
+**G4. Send to bundler**
+
+- Configurable bundler URL: per-chain env var `NEXT_PUBLIC_BUNDLER_URL_<chainId>` with a global `NEXT_PUBLIC_BUNDLER_URL` fallback; per-chain override via the AccountAbstractionPanel (stored in localStorage).
+- On threshold, the detail view shows a Send-to-bundler CTA. The hook calls `pm_getPaymasterData` (if a paymaster URL is configured), `eth_estimateUserOperationGas`, `eth_sendUserOperation`, then polls `eth_getUserOperationReceipt` until `success` is set.
+- The bundled tx hash is shown with the chain's explorer link.
+
+**G5. Paymaster**
+
+- Optional per-chain paymaster URL (`NEXT_PUBLIC_PAYMASTER_URL_<chainId>` / `NEXT_PUBLIC_PAYMASTER_URL`). The paymaster endpoint answers `pm_getPaymasterData`; the result is used verbatim for `paymasterAndData`, callGasLimit, and verificationGasLimit (Pimlico contract).
+- Sponsor signing is out of scope for v1.
+
+**G6. EntryPoint deposit**
+
+- Anyone can prefund via `EntryPoint.depositTo(wallet)` (existing).
+- Owner can withdraw via `EntryPoint.withdrawTo(recipient, amount)` from the panel.
+
+**G7. Storage**
+
+- The same `multisig_requests` table holds UserOp requests; the request JSONB carries `mode: 'userop'`, `userOpHash`, `userOpSigningHash`, `userOpJson`, `userOpReceipt`, `bundlerUrl`, `paymasterUrl`, and `userOpGas`. No schema migration.
+
+**Acceptance**
+
+- An Extended wallet can build, sign, and dispatch a UserOp end-to-end.
+- Hybrid votes (off-chain ECDSA + on-chain `approveHash`) reach the threshold and execute.
+- A paymaster (when configured) sponsors gas; without one, the wallet's EntryPoint deposit is debited.
+- The AccountAbstractionPanel surfaces the EntryPoint nonce, deposit, bundler URL, paymaster URL, and withdraw form.
+- Zero regressions on the classic `execTransaction` path.
+
+**Out of scope (v1)**
+
+- Auto gas price oracle (viem `estimateFeesPerGas` or the bundler's estimator suffices).
+- Multi-bundler failover.
+- UserOp simulation / `eth_simulateUserOpAssetChanges`.
+- Bundle traces from `debug_traceCall` against the EntryPoint.
+- Sponsor-signed paymaster flows (verifying paymaster stubs, signed sponsorship blobs).
+- `multiRequest` batch results on the UserOp path (the inner `execute(to, value, data)` only carries the URL-encoded `execute` call; per-step results would need a new wallet event).

--- a/src/components/buttons/ApproveUserOpRequest.stories.tsx
+++ b/src/components/buttons/ApproveUserOpRequest.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import ApproveUserOpRequest from './ApproveUserOpRequest'
+
+const meta: Meta<typeof ApproveUserOpRequest> = {
+  title: 'Buttons/ApproveUserOpRequest',
+  component: ApproveUserOpRequest
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof ApproveUserOpRequest> = (
+  args: React.ComponentProps<typeof ApproveUserOpRequest>
+) => <ApproveUserOpRequest {...args} />
+Basic.args = {
+  multiSigAddress: '0x2222222222222222222222222222222222222222',
+  userOpSigningHash: '0x5555555555555555555555555555555555555555555555555555555555555555'
+}

--- a/src/components/buttons/ApproveUserOpRequest.tsx
+++ b/src/components/buttons/ApproveUserOpRequest.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+
+import useApproveUserOpHash from '../../hooks/useApproveUserOpHash'
+
+interface ApproveUserOpRequestProps {
+  multiSigAddress: `0x${string}`
+  userOpSigningHash: `0x${string}`
+  onApproved?: () => void
+}
+
+// On-chain pre-approval of a UserOp digest. Callers (the request detail
+// view) hand us the `userOpSigningHash` (= `EIP191(userOpHash)`) the wallet
+// returns from `userOpSigningHash`; on-chain approval binds the same digest
+// the off-chain ECDSA path signs.
+const ApproveUserOpRequest: React.FC<ApproveUserOpRequestProps> = ({
+  multiSigAddress,
+  userOpSigningHash,
+  onApproved
+}) => {
+  const { writeContract, isPending, isFinal } = useApproveUserOpHash(multiSigAddress, userOpSigningHash)
+
+  useEffect(() => {
+    if (isFinal && onApproved) onApproved()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFinal])
+
+  return (
+    <Button variant='outline' className='mr-8 mt-4' onClick={() => writeContract()} disabled={isPending || isFinal}>
+      {isFinal ? 'Approved on-chain' : isPending ? 'Confirm in your wallet...' : 'Approve UserOp on-chain'}
+    </Button>
+  )
+}
+
+export default ApproveUserOpRequest

--- a/src/components/buttons/RevokeUserOpApproval.stories.tsx
+++ b/src/components/buttons/RevokeUserOpApproval.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import RevokeUserOpApproval from './RevokeUserOpApproval'
+
+const meta: Meta<typeof RevokeUserOpApproval> = {
+  title: 'Buttons/RevokeUserOpApproval',
+  component: RevokeUserOpApproval
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof RevokeUserOpApproval> = (
+  args: React.ComponentProps<typeof RevokeUserOpApproval>
+) => <RevokeUserOpApproval {...args} />
+Basic.args = {
+  multiSigAddress: '0x2222222222222222222222222222222222222222',
+  userOpSigningHash: '0x5555555555555555555555555555555555555555555555555555555555555555'
+}

--- a/src/components/buttons/RevokeUserOpApproval.tsx
+++ b/src/components/buttons/RevokeUserOpApproval.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+
+import useRevokeUserOpHash from '../../hooks/useRevokeUserOpHash'
+
+interface RevokeUserOpApprovalProps {
+  multiSigAddress: `0x${string}`
+  userOpSigningHash: `0x${string}`
+  onRevoked?: () => void
+}
+
+// 0.5.0 wallets only: withdraws the connected owner's on-chain approval of
+// a UserOp digest without burning the EntryPoint nonce. Self-only — the
+// wallet reverts with NotApproved() for a digest the owner never approved.
+const RevokeUserOpApproval: React.FC<RevokeUserOpApprovalProps> = ({
+  multiSigAddress,
+  userOpSigningHash,
+  onRevoked
+}) => {
+  const { writeContract, isPending, isFinal } = useRevokeUserOpHash(multiSigAddress, userOpSigningHash)
+
+  useEffect(() => {
+    if (isFinal && onRevoked) onRevoked()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFinal])
+
+  return (
+    <Button variant='outline' className='mr-8 mt-4' onClick={() => writeContract()} disabled={isPending || isFinal}>
+      {isFinal ? 'Approval revoked' : isPending ? 'Confirm in your wallet...' : 'Revoke my UserOp approval'}
+    </Button>
+  )
+}
+
+export default RevokeUserOpApproval

--- a/src/components/buttons/SignUserOp.stories.tsx
+++ b/src/components/buttons/SignUserOp.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import SignUserOp from './SignUserOp'
+
+const meta: Meta<typeof SignUserOp> = {
+  title: 'Buttons/SignUserOp',
+  component: SignUserOp
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof SignUserOp> = (args: React.ComponentProps<typeof SignUserOp>) => (
+  <SignUserOp {...args} />
+)
+Basic.args = {
+  wallet: '0x2222222222222222222222222222222222222222',
+  entryPoint: '0x0000000071727De22E5E9d8BDe0dFeC0CEB6a7d7',
+  nonce: 0n,
+  args: {
+    to: '0x3333333333333333333333333333333333333333',
+    value: '0',
+    data: '0x',
+    txnGas: '35000',
+    signatures: ''
+  },
+  description: 'Send 0.001 ETH via Account Abstraction'
+}

--- a/src/components/buttons/SignUserOp.tsx
+++ b/src/components/buttons/SignUserOp.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { Button } from '@/components/ui/button'
+
+import { MultiSigExecTransactionArgs, MultiSigTransactionRequest } from '../../models/MultiSigs'
+import useUserOpSigning from '../../hooks/useUserOpSigning'
+
+interface SignUserOpProps {
+  wallet: `0x${string}`
+  entryPoint: `0x${string}`
+  nonce: bigint | undefined
+  args: MultiSigExecTransactionArgs
+  description: string
+  requestDetails?: MultiSigTransactionRequest
+  existingRequestId?: string
+  bundlerUrl?: string
+  paymasterUrl?: string
+}
+
+// Mirrors SignRequest for the UserOp path: each owner presses Sign, signs
+// the EntryPoint userOpHash via personal_sign, and the vote is appended to
+// the request's signature blob. Once the threshold is reached, the
+// SubmitUserOpRequest button sends the combined blob to the bundler.
+const SignUserOp: React.FC<SignUserOpProps> = ({
+  wallet,
+  entryPoint,
+  nonce,
+  args,
+  description,
+  requestDetails,
+  existingRequestId,
+  bundlerUrl,
+  paymasterUrl
+}) => {
+  const { isPrepareError, isError, prepareError, error, isPending, isSuccess, signMessage, reset } = useUserOpSigning({
+    wallet,
+    entryPoint,
+    args,
+    description,
+    ...(requestDetails != null ? { existingRequest: requestDetails } : {}),
+    ...(existingRequestId != null ? { existingRequestId } : {}),
+    nonce,
+    bundlerUrl,
+    paymasterUrl
+  })
+
+  return (
+    <div className='flex justify-center'>
+      {isPrepareError || isError ? (
+        <div className='flex flex-col items-center gap-2'>
+          <p className='pt-2 text-xl font-bold text-destructive'>Something went wrong</p>
+          {error != null && <p className='pt-2 text-lg text-destructive'>{JSON.stringify(error)}</p>}
+          {prepareError != null && <p className='pt-2 text-lg text-destructive'>{String(prepareError)}</p>}
+          <Button variant='default' className='mr-8 mt-4' onClick={() => reset()} disabled={isPending || isSuccess}>
+            Try again
+          </Button>
+        </div>
+      ) : (
+        <Button variant='default' className='mr-8 mt-4' onClick={() => signMessage()} disabled={isPending || isSuccess}>
+          {isSuccess ? 'Signed UserOp' : 'Sign UserOp'}
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export default SignUserOp

--- a/src/components/buttons/SubmitUserOpRequest.stories.tsx
+++ b/src/components/buttons/SubmitUserOpRequest.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import SubmitUserOpRequest from './SubmitUserOpRequest'
+
+const meta: Meta<typeof SubmitUserOpRequest> = {
+  title: 'Buttons/SubmitUserOpRequest',
+  component: SubmitUserOpRequest
+}
+
+export default meta
+
+export const Basic: StoryFn<typeof SubmitUserOpRequest> = (args: React.ComponentProps<typeof SubmitUserOpRequest>) => (
+  <SubmitUserOpRequest {...args} />
+)
+Basic.args = {
+  wallet: '0x2222222222222222222222222222222222222222',
+  entryPoint: '0x0000000071727De22E5E9d8BDe0dFeC0CEB6a7d7',
+  bundlerUrl: 'https://api.pimlico.io/v2/sepolia/rpc',
+  walletVersion: '0.5.0',
+  existingRequestId: '00000000-0000-0000-0000-000000000000',
+  requestDetails: {
+    id: '00000000-0000-0000-0000-000000000000',
+    multiSigAddress: '0x2222222222222222222222222222222222222222',
+    description: 'Send 0.001 ETH via Account Abstraction',
+    submitter: '0x2222222222222222222222222222222222222222',
+    signatures: [],
+    ownerSigners: [],
+    dateSubmitted: new Date().toISOString(),
+    dateExecuted: '',
+    isActive: true,
+    isExecuted: false,
+    isCancelled: false,
+    isConfirmed: false,
+    isSuccessful: false,
+    request: {
+      to: '0x3333333333333333333333333333333333333333',
+      value: '0',
+      data: '0x',
+      txnGas: '35000',
+      signatures: '',
+      mode: 'userop'
+    }
+  }
+}

--- a/src/components/buttons/SubmitUserOpRequest.tsx
+++ b/src/components/buttons/SubmitUserOpRequest.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { Button } from '@/components/ui/button'
+
+import { MultiSigTransactionRequest } from '../../models/MultiSigs'
+import useSendUserOp from '../../hooks/useSendUserOp'
+
+interface SubmitUserOpRequestProps {
+  wallet: `0x${string}`
+  entryPoint: `0x${string}`
+  bundlerUrl: string
+  paymasterUrl?: string
+  walletVersion: string | undefined
+  requestDetails: MultiSigTransactionRequest
+  existingRequestId: string
+}
+
+// Mirrors ExecuteRequest for the UserOp path. The hook assembles the
+// PackedUserOperation from the request's persisted userOpJson + signature
+// blob, optionally calls pm_getPaymasterData, refines gas via the bundler,
+// then sends and polls the receipt.
+const SubmitUserOpRequest: React.FC<SubmitUserOpRequestProps> = ({
+  wallet,
+  entryPoint,
+  bundlerUrl,
+  paymasterUrl,
+  walletVersion,
+  requestDetails,
+  existingRequestId
+}) => {
+  const { state, send } = useSendUserOp({
+    request: requestDetails,
+    entryPoint,
+    bundlerUrl,
+    paymasterUrl,
+    walletVersion
+  })
+
+  const sending = state.status === 'estimating' || state.status === 'sending'
+  const settled = state.status === 'mined' || state.status === 'failed'
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <Button
+        variant='default'
+        className='mr-8 mt-4'
+        onClick={() => {
+          void send()
+        }}
+        disabled={sending || settled}
+      >
+        {state.status === 'estimating' && 'Estimating gas...'}
+        {state.status === 'sending' && 'Sending to bundler...'}
+        {state.status === 'submitted' && 'Submitted — awaiting receipt'}
+        {state.status === 'polling' && 'Submitted — awaiting receipt'}
+        {state.status === 'mined' && 'Bundled and mined'}
+        {state.status === 'failed' && 'Send failed — try again'}
+        {state.status === 'idle' && 'Send to bundler'}
+      </Button>
+      {state.status === 'failed' && <p className='text-sm text-destructive'>{state.reason}</p>}
+      {state.status === 'mined' && <p className='text-sm text-primary'>Bundled in tx {state.receipt.txHash}</p>}
+    </div>
+  )
+}
+
+export default SubmitUserOpRequest

--- a/src/components/forms/CreateMultiSigRequestForm.tsx
+++ b/src/components/forms/CreateMultiSigRequestForm.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useState } from 'react'
-import { useAccount } from 'wagmi'
+import { useAccount, useChainId } from 'wagmi'
 import { encodeFunctionData, type Abi } from 'viem'
 import MyMultiSig from 'mymultisig-contract/abi/MyMultiSig.json'
 import { JsonFragment } from '@ethersproject/abi'
@@ -11,11 +11,15 @@ import { Switch } from '@/components/ui/switch'
 import TextInput from '../inputs/TextInput'
 import AddressBookInput from '../inputs/AddressBookInput'
 import SignRequest from '../buttons/SignRequest'
+import SignUserOp from '../buttons/SignUserOp'
 import NewContract from '../modals/NewContract'
 import { AddIcon, DeleteIcon } from '../icons/ChakraIcons'
 import useContracts from '../../states/contracts'
 import useMultiSigDetails from '../../hooks/useMultiSigDetails'
 import useWalletType from '../../hooks/useWalletType'
+import useAdvancedFeatures from '../../hooks/useAdvancedFeatures'
+import useEntryPointNonce from '../../hooks/useEntryPointNonce'
+import useBundlerConfig from '../../states/bundlerConfig'
 import { buildRawSignatureFromFunction } from '../../utils/buildFunctionSignature'
 import { isModernWallet } from '../../utils/contractVersions'
 
@@ -44,6 +48,10 @@ const EMPTY_STEP: RequestStep = {
   txnGas: '35000',
   data: '0x'
 }
+
+// useChainId() returns the wagmi-context chain id; this thin wrapper makes
+// the line above read more naturally when we need it outside the hook list.
+const useChainIdSafe = () => useChainId()
 
 // Gas consumed by the multiRequest loop itself, on top of the inner calls.
 const BATCH_OVERHEAD_GAS = 50000
@@ -89,16 +97,27 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
   const [expiry, setExpiry] = useState('')
   const [strictBatch, setStrictBatch] = useState(false)
   const [delegateCall, setDelegateCall] = useState(false)
+  const [useBundler, setUseBundler] = useState(false)
   const [newContractKey, setNewContractKey] = useState(0)
   const [showNewContract, setShowNewContract] = useState(false)
   const contracts = useContracts((state) => state.contracts)
   const { address } = useAccount()
   const { walletType, allowOnlyOwnerRequest } = useWalletType(multiSigAddress)
   const { data: detailsData } = useMultiSigDetails(multiSigAddress, address ?? '0x')
+  const { supportsAdvanced, entryPoint } = useAdvancedFeatures(multiSigAddress)
+  const { nonce: entryPointNonce } = useEntryPointNonce(entryPoint, multiSigAddress)
+  const getBundlerUrl = useBundlerConfig((s) => s.getBundlerUrl)
+  const getPaymasterUrl = useBundlerConfig((s) => s.getPaymasterUrl)
+  const bundlerUrl = getBundlerUrl(useChainIdSafe())
+  const paymasterUrl = getPaymasterUrl(useChainIdSafe())
   // 0.5.0 wallets: optional signature expiry, atomic batches, and (Extended)
   // a DELEGATECALL operation byte gated on-chain to the wallet itself.
   const walletVersion = detailsData != null ? String(detailsData[1]) : undefined
   const modern = isModernWallet(walletVersion)
+  // The bundler toggle is only meaningful on 0.5.0 Extended wallets (the
+  // only type that exposes the ERC-4337 surface).
+  const bundlerAvailable = supportsAdvanced && entryPoint != null && walletType === 'extended'
+  const bundlerConfigured = bundlerUrl != null && bundlerUrl !== ''
   // Extended wallets can restrict request creation to owners; the API enforces
   // the same rule server-side.
   const isOwner = detailsData != null ? Boolean(detailsData[5]) : undefined
@@ -157,13 +176,25 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
   const firstInvalidIndex = steps.findIndex((s) => stepError(s) != null)
   const stepsValid = firstInvalidIndex === -1
   const expiryValid = expiry === '' || new Date(expiry).getTime() > Date.now()
-  const ready = stepsValid && description.trim() !== '' && expiryValid
   const isBatch = steps.length > 1
+  // Bundler mode is single-step only (the wallet's execute(to,value,data)
+  // entry can't carry a multiRequest sequence) and disables EIP-712-only
+  // options (validUntil, operation, pinned nonce).
+  const bundlerModeEffective = useBundler && bundlerAvailable
+  const ready =
+    stepsValid &&
+    description.trim() !== '' &&
+    expiryValid &&
+    (!bundlerModeEffective || (!isBatch && entryPoint != null && bundlerConfigured))
   const totalStepGas = steps.reduce((sum, s) => (isUint(s.txnGas) ? sum + Number(s.txnGas) : sum), 0)
   // DELEGATECALL is only accepted on-chain when the target is the wallet
   // itself, so the toggle only applies to a single self-targeted step.
   const delegateCallAvailable =
-    modern && walletType === 'extended' && !isBatch && steps[0].to.toLowerCase() === multiSigAddress.toLowerCase()
+    !bundlerModeEffective &&
+    modern &&
+    walletType === 'extended' &&
+    !isBatch &&
+    steps[0].to.toLowerCase() === multiSigAddress.toLowerCase()
 
   // Sign args: a single step goes out as-is; several steps self-call
   // multiRequest (or multiRequestStrict for atomic 0.5.0 batches) so all of
@@ -246,7 +277,12 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
                   {isBatch ? `Step ${i + 1}` : 'What should this request do?'}
                 </h3>
                 {isBatch && (
-                  <Button variant='outline' size='icon' aria-label={`Remove step ${i + 1}`} onClick={() => removeStep(i)}>
+                  <Button
+                    variant='outline'
+                    size='icon'
+                    aria-label={`Remove step ${i + 1}`}
+                    onClick={() => removeStep(i)}
+                  >
                     <DeleteIcon className='h-4 w-4' />
                   </Button>
                 )}
@@ -294,16 +330,16 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
                 functions.length > 0 &&
                 field(
                   'Function to call',
-                  <Select
-                    value={step.functionSig}
-                    onValueChange={(v) => updateStep(i, { functionSig: v, args: {} })}
-                  >
+                  <Select value={step.functionSig} onValueChange={(v) => updateStep(i, { functionSig: v, args: {} })}>
                     <SelectTrigger className='w-full'>
                       <SelectValue placeholder='Select a function' />
                     </SelectTrigger>
                     <SelectContent>
                       {functions.map((item) => (
-                        <SelectItem key={buildRawSignatureFromFunction(item)} value={buildRawSignatureFromFunction(item)}>
+                        <SelectItem
+                          key={buildRawSignatureFromFunction(item)}
+                          value={buildRawSignatureFromFunction(item)}
+                        >
                           {item.name}
                         </SelectItem>
                       ))}
@@ -328,7 +364,9 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
                           className='md:w-full'
                           placeholder={input.type?.includes('[') ? `JSON array, e.g. ["a", "b"]` : String(input.name)}
                           value={step.args[String(input.name)] ?? ''}
-                          onChange={(e) => updateStep(i, { args: { ...step.args, [String(input.name)]: e.target.value } })}
+                          onChange={(e) =>
+                            updateStep(i, { args: { ...step.args, [String(input.name)]: e.target.value } })
+                          }
                         />
                       )
                     )
@@ -387,7 +425,7 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
         })}
 
         <div className='flex flex-wrap items-center justify-between gap-2'>
-          <Button variant='outline' className='gap-2' onClick={addStep}>
+          <Button variant='outline' className='gap-2' onClick={addStep} disabled={bundlerModeEffective}>
             <AddIcon className='h-4 w-4' />
             Add a step
           </Button>
@@ -395,6 +433,11 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
             <span className='font-mono text-xs text-muted-foreground'>
               {steps.length} steps · {totalStepGas.toLocaleString()} gas + {BATCH_OVERHEAD_GAS.toLocaleString()} batch
               overhead
+            </span>
+          ) : bundlerModeEffective ? (
+            <span className='text-xs text-muted-foreground'>
+              Bundler mode is single-step only — the wallet&apos;s execute(to,value,data) entry does not carry a
+              multiRequest sequence.
             </span>
           ) : (
             <span className='text-xs text-muted-foreground'>
@@ -415,6 +458,7 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
             />
           )}
           {walletType === 'extended' &&
+            !bundlerModeEffective &&
             field(
               'Pin to nonce (optional)',
               <TextInput
@@ -426,6 +470,7 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
               'Binds the request to an exact nonce so it can be pre-signed or ordered explicitly.'
             )}
           {modern &&
+            !bundlerModeEffective &&
             field(
               'Signatures expire (optional)',
               <TextInput
@@ -440,7 +485,7 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
                 ? 'The deadline is signed into every approval; the wallet refuses the request past it. Leave empty for no expiry.'
                 : 'The expiry must be in the future.'
             )}
-          {isBatch && modern && (
+          {isBatch && modern && !bundlerModeEffective && (
             <div className='flex items-center gap-3'>
               <Switch checked={strictBatch} onCheckedChange={setStrictBatch} />
               <div className='flex flex-col'>
@@ -458,8 +503,31 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
               <div className='flex flex-col'>
                 <span className='text-sm font-medium text-foreground'>Execute as DELEGATECALL</span>
                 <span className='text-xs text-muted-foreground'>
-                  Runs the calldata in the wallet&apos;s own storage context (operation byte 1). The wallet only
-                  accepts this for calls targeting itself. For experts — a wrong payload can corrupt the wallet.
+                  Runs the calldata in the wallet&apos;s own storage context (operation byte 1). The wallet only accepts
+                  this for calls targeting itself. For experts — a wrong payload can corrupt the wallet.
+                </span>
+              </div>
+            </div>
+          )}
+          {bundlerAvailable && (
+            <div className='flex items-center gap-3'>
+              <Switch
+                checked={useBundler}
+                onCheckedChange={(next) => {
+                  setUseBundler(next)
+                  // DELEGATECALL and a UserOp are mutually exclusive on the
+                  // ERC-4337 path: the wallet only accepts a plain CALL into
+                  // `execute(to, value, data)` from the EntryPoint.
+                  if (next) setDelegateCall(false)
+                }}
+              />
+              <div className='flex flex-col'>
+                <span className='text-sm font-medium text-foreground'>Submit via bundler (ERC-4337)</span>
+                <span className='text-xs text-muted-foreground'>
+                  {bundlerConfigured
+                    ? 'Owners sign the EntryPoint userOpHash via personal_sign; once the threshold is reached, send the UserOp to the configured bundler.'
+                    : 'No bundler configured for this chain — set one on the Owners & settings tab before sending.'}{' '}
+                  Batch + DELEGATECALL options are disabled on this path.
                 </span>
               </div>
             </div>
@@ -467,7 +535,21 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
         </div>
 
         <div className='flex flex-col items-end gap-1.5'>
-          {ready && signArgs != null ? (
+          {ready && signArgs != null && bundlerModeEffective && entryPoint != null ? (
+            <SignUserOp
+              wallet={multiSigAddress}
+              entryPoint={entryPoint}
+              nonce={entryPointNonce}
+              bundlerUrl={bundlerUrl}
+              paymasterUrl={paymasterUrl}
+              description={description}
+              args={{
+                ...signArgs,
+                signatures: '',
+                mode: 'userop'
+              }}
+            />
+          ) : ready && signArgs != null ? (
             <SignRequest
               multiSigAddress={multiSigAddress}
               description={description}
@@ -486,16 +568,20 @@ const CreateMultiSigRequestForm: React.FC<CreateMultiSigRequestFormProps> = ({ m
           ) : (
             <Fragment>
               {/* Same look and position as SignRequest's button, disabled until the request is complete. */}
-              <div className='flex justify-center'>
+              <div className='flex flex-col items-center gap-2'>
                 <Button variant='default' className='mr-8 mt-4' disabled>
-                  Sign transaction request
+                  {bundlerModeEffective ? 'Sign UserOp' : 'Sign transaction request'}
                 </Button>
+                <p className='mr-8 text-xs text-muted-foreground'>
+                  {bundlerModeEffective && !bundlerConfigured
+                    ? 'No bundler configured for this chain — set one on the Owners & settings tab.'
+                    : bundlerModeEffective && isBatch
+                      ? 'Bundler mode is single-step only.'
+                      : firstInvalidIndex !== -1
+                        ? `${isBatch ? `Step ${firstInvalidIndex + 1}` : 'The request'} ${stepError(steps[firstInvalidIndex])}.`
+                        : 'Add a description so the other owners know what this request does.'}
+                </p>
               </div>
-              <p className='mr-8 text-xs text-muted-foreground'>
-                {firstInvalidIndex !== -1
-                  ? `${isBatch ? `Step ${firstInvalidIndex + 1}` : 'The request'} ${stepError(steps[firstInvalidIndex])}.`
-                  : 'Add a description so the other owners know what this request does.'}
-              </p>
             </Fragment>
           )}
         </div>

--- a/src/components/multiSigDetails/AccountAbstractionPanel.tsx
+++ b/src/components/multiSigDetails/AccountAbstractionPanel.tsx
@@ -3,27 +3,52 @@ import { formatEther } from 'viem'
 import { Button } from '@/components/ui/button'
 
 import TextInput from '../inputs/TextInput'
+import AddressBookInput from '../inputs/AddressBookInput'
 import useAdvancedFeatures from '../../hooks/useAdvancedFeatures'
 import useEntryPointDeposit from '../../hooks/useEntryPointDeposit'
+import useEntryPointNonce from '../../hooks/useEntryPointNonce'
+import useBundlerConfig from '../../states/bundlerConfig'
+import { useChainId } from 'wagmi'
 
 interface AccountAbstractionPanelProps {
   multiSigAddress: `0x${string}`
 }
 
 const isUint = (value: string) => /^\d+$/.test(value)
+const isAddress = (value: string) => /^0x[a-fA-F0-9]{40}$/.test(value)
 
 // ERC-4337 surface of a 0.5.0 Extended wallet: it validates UserOperations
 // against the pinned EntryPoint v0.7, so bundlers can execute owner-approved
-// transactions and pay gas from the wallet's EntryPoint deposit. This panel
-// shows the EntryPoint binding and lets anyone prefund the deposit.
+// transactions and pay gas from the wallet's EntryPoint deposit (or a
+// paymaster). This panel shows the EntryPoint binding, lets anyone prefund
+// the deposit, lets the owner withdraw it, and surfaces the bundler /
+// paymaster URLs the request builder uses.
 const AccountAbstractionPanel: React.FC<AccountAbstractionPanelProps> = ({ multiSigAddress }) => {
+  const chainId = useChainId()
   const { supportsAdvanced, entryPoint } = useAdvancedFeatures(multiSigAddress)
-  const { depositBalance, deposit, isPending } = useEntryPointDeposit(entryPoint, multiSigAddress)
+  const { depositBalance, deposit, withdraw, isPending } = useEntryPointDeposit(entryPoint, multiSigAddress)
+  const { nonce: entryPointNonce } = useEntryPointNonce(entryPoint, multiSigAddress)
+  const { perChain, setConfig } = useBundlerConfig()
+  const config = chainId != null ? (perChain[chainId] ?? {}) : {}
+
   const [amount, setAmount] = useState('')
+  const [withdrawRecipient, setWithdrawRecipient] = useState('')
+  const [withdrawAmount, setWithdrawAmount] = useState('')
+  const [bundlerUrl, setBundlerUrl] = useState(config.bundlerUrl ?? '')
+  const [paymasterUrl, setPaymasterUrl] = useState(config.paymasterUrl ?? '')
 
   if (!supportsAdvanced || entryPoint == null) return null
 
   const ready = isUint(amount) && amount !== '' && BigInt(amount) > 0n
+  const withdrawReady = isAddress(withdrawRecipient) && isUint(withdrawAmount) && BigInt(withdrawAmount) > 0n
+  const saveBundlerUrl = (value: string) => {
+    setBundlerUrl(value)
+    if (chainId != null) setConfig(chainId, { bundlerUrl: value === '' ? undefined : value })
+  }
+  const savePaymasterUrl = (value: string) => {
+    setPaymasterUrl(value)
+    if (chainId != null) setConfig(chainId, { paymasterUrl: value === '' ? undefined : value })
+  }
 
   return (
     <div className='flex w-full flex-col gap-3 rounded-lg border border-border p-4'>
@@ -45,6 +70,12 @@ const AccountAbstractionPanel: React.FC<AccountAbstractionPanelProps> = ({ multi
             {depositBalance != null ? `${formatEther(depositBalance)} ETH` : '...'}
           </span>
         </span>
+        <span className='text-muted-foreground'>
+          EntryPoint nonce:{' '}
+          <span className='font-mono text-foreground'>
+            {entryPointNonce != null ? entryPointNonce.toString() : '...'}
+          </span>
+        </span>
       </div>
       <div className='flex flex-wrap items-end gap-2'>
         <div className='flex flex-col gap-1.5'>
@@ -60,9 +91,60 @@ const AccountAbstractionPanel: React.FC<AccountAbstractionPanelProps> = ({ multi
           {isPending ? 'Confirm in your wallet...' : 'Deposit'}
         </Button>
       </div>
+      <div className='flex flex-wrap items-end gap-2'>
+        <div className='flex flex-1 flex-col gap-1.5'>
+          <span className='text-sm font-semibold text-foreground'>Withdraw to (recipient)</span>
+          <AddressBookInput
+            placeholder='0x...'
+            value={withdrawRecipient}
+            isInvalid={withdrawRecipient !== '' && !isAddress(withdrawRecipient)}
+            onChange={setWithdrawRecipient}
+          />
+        </div>
+        <div className='flex flex-col gap-1.5'>
+          <span className='text-sm font-semibold text-foreground'>Amount (wei)</span>
+          <TextInput
+            placeholder='0'
+            value={withdrawAmount}
+            isInvalid={withdrawAmount !== '' && !isUint(withdrawAmount)}
+            onChange={(e) => setWithdrawAmount(e.target.value.trim())}
+          />
+        </div>
+        <Button
+          variant='outline'
+          disabled={!withdrawReady || isPending}
+          onClick={() => withdraw(withdrawRecipient as `0x${string}`, BigInt(withdrawAmount))}
+        >
+          Withdraw
+        </Button>
+      </div>
+      <div className='flex flex-col gap-2 rounded-lg border border-border p-3'>
+        <span className='text-sm font-semibold text-foreground'>Bundler + paymaster (per chain)</span>
+        <div className='flex flex-col gap-1.5'>
+          <span className='text-xs text-muted-foreground'>Bundler URL (JSON-RPC; eth_sendUserOperation)</span>
+          <TextInput
+            placeholder='https://api.pimlico.io/v2/<chain>/rpc'
+            value={bundlerUrl}
+            onChange={(e) => saveBundlerUrl(e.target.value.trim())}
+          />
+        </div>
+        <div className='flex flex-col gap-1.5'>
+          <span className='text-xs text-muted-foreground'>Paymaster URL (optional; pm_getPaymasterData)</span>
+          <TextInput
+            placeholder='https://api.pimlico.io/v2/<chain>/rpc'
+            value={paymasterUrl}
+            onChange={(e) => savePaymasterUrl(e.target.value.trim())}
+          />
+        </div>
+        <p className='text-xs text-muted-foreground'>
+          Configured URLs are saved per chain in your browser. Leave blank to use the NEXT_PUBLIC_BUNDLER_URL /
+          NEXT_PUBLIC_PAYMASTER_URL env vars when available.
+        </p>
+      </div>
       <p className='text-xs text-muted-foreground'>
-        UserOperations bind the wallet&apos;s current nonce and the same owner-signature threshold as a direct
-        execution; the deposit only covers gas.
+        UserOperations use the EntryPoint&apos;s 2D nonce (independent of the wallet&apos;s own transaction nonce) and
+        the same owner-signature threshold as a direct execution. Owners sign the EntryPoint userOpHash via
+        personal_sign; the wallet&apos;s `userOpSigningHash` is the EIP-191 wrap of that digest.
       </p>
     </div>
   )

--- a/src/components/multiSigDetails/MultiSigRequestDetail.tsx
+++ b/src/components/multiSigDetails/MultiSigRequestDetail.tsx
@@ -7,6 +7,7 @@ import ExecuteRequest from '../buttons/ExecuteRequest'
 import ApproveRequest from '../buttons/ApproveRequest'
 import RevokeApproval from '../buttons/RevokeApproval'
 import ScheduledExecutionPanel from './ScheduledExecutionPanel'
+import UserOpRequestCard from './UserOpRequestCard'
 import { isModernWallet } from '../../utils/contractVersions'
 import useMultiSigRequestDetails from '../../hooks/useMultiSigRequestDetails'
 import useDeleteMultiSigRequest from '../../hooks/useDeleteMultiSigRequest'
@@ -20,10 +21,7 @@ interface MultiSigRequestDetailProps {
   multiSigRequestId: string
 }
 
-const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
-  address,
-  multiSigRequestId
-}) => {
+const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({ address, multiSigRequestId }) => {
   const [isDeleted, setIsDeleted] = useState(false)
   const [isReset, setIsReset] = useState(false)
   const requestDetails = useMultiSigRequestDetails(multiSigRequestId)
@@ -44,10 +42,34 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
 
   if (requestDetails == null || multiSigDetails == null) return null
 
+  // UserOp requests render a dedicated card (personal_sign votes, on-chain
+  // approveHash(userOpSigningHash), bundler submit). The classic multisig
+  // card below is skipped entirely so the two flows don't conflate.
+  if (requestDetails.request.mode === 'userop') {
+    return (
+      <Fragment>
+        <div className='flex gap-2 px-6'>
+          <Button asChild>
+            <Link href={`/multisig/${requestDetails.multiSigAddress}/buildRequest`}>Build a request</Link>
+          </Button>
+          <Button asChild variant='outline'>
+            <Link href={`/multisig/${requestDetails.multiSigAddress}/requests`}>Consult requests</Link>
+          </Button>
+        </div>
+        <UserOpRequestCard
+          request={requestDetails}
+          threshold={multiSigDetails.threshold}
+          onDelete={() => setIsDeleted(true)}
+          onReset={() => setIsReset(true)}
+        />
+      </Fragment>
+    )
+  }
+
   const row = (label: string, value: React.ReactNode) => (
-    <div key={label} className="flex flex-wrap items-center gap-2">
-      <span className="px-2 pt-2 text-xl font-bold text-foreground">{label}</span>
-      <span className="px-2 pt-2 text-lg font-bold text-foreground">{value}</span>
+    <div key={label} className='flex flex-wrap items-center gap-2'>
+      <span className='px-2 pt-2 text-xl font-bold text-foreground'>{label}</span>
+      <span className='px-2 pt-2 text-lg font-bold text-foreground'>{value}</span>
     </div>
   )
 
@@ -75,32 +97,21 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
 
   return (
     <Fragment>
-      <div className="flex gap-2 px-6">
+      <div className='flex gap-2 px-6'>
         <Button asChild>
-          <Link href={`/multisig/${requestDetails.multiSigAddress}/buildRequest`}>
-            Build a request
-          </Link>
+          <Link href={`/multisig/${requestDetails.multiSigAddress}/buildRequest`}>Build a request</Link>
         </Button>
-        <Button asChild variant="outline">
-          <Link href={`/multisig/${requestDetails.multiSigAddress}/requests`}>
-            Consult requests
-          </Link>
+        <Button asChild variant='outline'>
+          <Link href={`/multisig/${requestDetails.multiSigAddress}/requests`}>Consult requests</Link>
         </Button>
       </div>
-      <div className="mt-4 rounded-lg border border-border p-4">
+      <div className='mt-4 rounded-lg border border-border p-4'>
         {row('Description', requestDetails.description)}
-        {row(
-          'Submitted date',
-          new Date(Number(requestDetails.dateSubmitted)).toLocaleDateString()
-        )}
+        {row('Submitted date', new Date(Number(requestDetails.dateSubmitted)).toLocaleDateString())}
         {row('Target', requestDetails.request.to)}
-        <div className="flex flex-wrap items-start gap-2">
-          <span className="px-2 pt-2 text-xl font-bold text-foreground">Data</span>
-          <Textarea
-            readOnly
-            defaultValue={requestDetails.request.data}
-            className="min-h-[80px] flex-1"
-          />
+        <div className='flex flex-wrap items-start gap-2'>
+          <span className='px-2 pt-2 text-xl font-bold text-foreground'>Data</span>
+          <Textarea readOnly defaultValue={requestDetails.request.data} className='min-h-[80px] flex-1' />
         </div>
         {row('Value', requestDetails.request.value)}
         {row('Tx. Gas', requestDetails.request.txnGas)}
@@ -116,7 +127,9 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
             </span>
           )}
         {isDelegateCall && row('Operation', 'DELEGATECALL (runs in the wallet’s own storage context)')}
-        {batchSteps != null && batchSteps.length > 0 && requestDetails.request.strictBatch === true &&
+        {batchSteps != null &&
+          batchSteps.length > 0 &&
+          requestDetails.request.strictBatch === true &&
           row('Batch mode', 'Atomic — the first failing step reverts every step')}
         {row(
           'Approvals / Threshold',
@@ -128,25 +141,23 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
         )}
 
         {batchSteps != null && batchSteps.length > 0 && (
-          <div className="mt-2 flex flex-col gap-2 px-2">
-            <span className="text-xl font-bold text-foreground">Batch steps</span>
-            <p className="text-sm text-muted-foreground">
+          <div className='mt-2 flex flex-col gap-2 px-2'>
+            <span className='text-xl font-bold text-foreground'>Batch steps</span>
+            <p className='text-sm text-muted-foreground'>
               Steps run in order; a failed step does not revert the others.
             </p>
             {batchSteps.map((step, i) => {
               const result = batchResults?.[i]
               return (
-                <div key={i} className="flex flex-wrap items-center gap-2 rounded border border-border p-2 text-sm">
-                  <span className="font-semibold text-foreground">#{i + 1}</span>
-                  <span className="font-mono text-foreground">{step.to}</span>
-                  <span className="text-muted-foreground">value {step.value}</span>
+                <div key={i} className='flex flex-wrap items-center gap-2 rounded border border-border p-2 text-sm'>
+                  <span className='font-semibold text-foreground'>#{i + 1}</span>
+                  <span className='font-mono text-foreground'>{step.to}</span>
+                  <span className='text-muted-foreground'>value {step.value}</span>
                   {result != null && (
-                    <span
-                      className={`font-semibold ${
-                        result.success ? 'text-primary' : 'text-destructive'
-                      }`}
-                    >
-                      {result.success ? 'succeeded' : `failed${result.returnData !== '0x' ? ` (${result.returnData})` : ''}`}
+                    <span className={`font-semibold ${result.success ? 'text-primary' : 'text-destructive'}`}>
+                      {result.success
+                        ? 'succeeded'
+                        : `failed${result.returnData !== '0x' ? ` (${result.returnData})` : ''}`}
                     </span>
                   )}
                 </div>
@@ -156,7 +167,7 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
         )}
 
         {requestDetails.isExecuted ? (
-          <div className="px-2 pt-2 text-xl font-bold text-primary">
+          <div className='px-2 pt-2 text-xl font-bold text-primary'>
             This request has been executed
             {requestDetails.dateExecuted != null &&
               ` on the ${new Date(Number(requestDetails.dateExecuted)).toLocaleDateString()}`}
@@ -164,21 +175,18 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
         ) : (
           <Fragment>
             {isExpired && (
-              <div className="px-2 pt-2 text-lg font-bold text-destructive">
+              <div className='px-2 pt-2 text-lg font-bold text-destructive'>
                 This request&apos;s signatures expired on {new Date(Number(validUntil) * 1000).toLocaleString()}. The
-                wallet refuses them (SignatureExpired). Reset the signatures and collect them again with a new
-                deadline.
+                wallet refuses them (SignatureExpired). Reset the signatures and collect them again with a new deadline.
               </div>
             )}
             {thresholdReached && !isExpired && (
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="px-2 pt-2 text-xl font-bold text-foreground">
-                  Execute this request
-                </span>
+              <div className='flex flex-wrap items-center gap-2'>
+                <span className='px-2 pt-2 text-xl font-bold text-foreground'>Execute this request</span>
                 {preflightBlocked ? (
-                  <span className="px-2 pt-2 text-lg font-bold text-destructive">
-                    The wallet rejects the collected approvals (owners may have changed or the nonce moved).
-                    Reset the signatures and collect them again.
+                  <span className='px-2 pt-2 text-lg font-bold text-destructive'>
+                    The wallet rejects the collected approvals (owners may have changed or the nonce moved). Reset the
+                    signatures and collect them again.
                   </span>
                 ) : (
                   <ExecuteRequest
@@ -198,14 +206,12 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
                 thresholdReached={thresholdReached}
               />
             )}
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="px-2 pt-2 text-xl font-bold text-foreground">Sign this request</span>
+            <div className='flex flex-wrap items-center gap-2'>
+              <span className='px-2 pt-2 text-xl font-bold text-foreground'>Sign this request</span>
               {hasSigned ? (
-                <span className="px-2 pt-2 text-xl font-bold text-primary">
-                  You already signed this request
-                </span>
+                <span className='px-2 pt-2 text-xl font-bold text-primary'>You already signed this request</span>
               ) : hasApproved ? (
-                <span className="px-2 pt-2 text-lg font-bold text-muted-foreground">
+                <span className='px-2 pt-2 text-lg font-bold text-muted-foreground'>
                   You approved on-chain; a signature would be a duplicate vote
                 </span>
               ) : (
@@ -219,10 +225,8 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
               )}
             </div>
             {supportsHybrid && txHash != null && !hasApproved && !hasSigned && (
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="px-2 pt-2 text-xl font-bold text-foreground">
-                  Or approve on-chain
-                </span>
+              <div className='flex flex-wrap items-center gap-2'>
+                <span className='px-2 pt-2 text-xl font-bold text-foreground'>Or approve on-chain</span>
                 <ApproveRequest
                   multiSigAddress={requestDetails.multiSigAddress}
                   txHash={txHash}
@@ -231,10 +235,8 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
               </div>
             )}
             {modern && txHash != null && hasApproved && (
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="px-2 pt-2 text-xl font-bold text-foreground">
-                  Withdraw your approval
-                </span>
+              <div className='flex flex-wrap items-center gap-2'>
+                <span className='px-2 pt-2 text-xl font-bold text-foreground'>Withdraw your approval</span>
                 <RevokeApproval
                   multiSigAddress={requestDetails.multiSigAddress}
                   txHash={txHash}
@@ -242,27 +244,23 @@ const MultiSigRequestDetail: React.FC<MultiSigRequestDetailProps> = ({
                 />
               </div>
             )}
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="px-2 pt-2 text-xl font-bold text-foreground">Clear signatures</span>
-              <Button variant="outline" className="mx-2 mt-2" onClick={() => setIsReset(true)}>
+            <div className='flex flex-wrap items-center gap-2'>
+              <span className='px-2 pt-2 text-xl font-bold text-foreground'>Clear signatures</span>
+              <Button variant='outline' className='mx-2 mt-2' onClick={() => setIsReset(true)}>
                 Reset signatures
               </Button>
             </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="px-2 pt-2 text-xl font-bold text-foreground">Delete this request</span>
-              <Button
-                variant="destructive"
-                className="mx-2 mt-2"
-                onClick={() => setIsDeleted(true)}
-              >
+            <div className='flex flex-wrap items-center gap-2'>
+              <span className='px-2 pt-2 text-xl font-bold text-foreground'>Delete this request</span>
+              <Button variant='destructive' className='mx-2 mt-2' onClick={() => setIsDeleted(true)}>
                 Delete
               </Button>
             </div>
           </Fragment>
         )}
       </div>
-      <div className="flex justify-center">
-        <Button asChild className="m-4">
+      <div className='flex justify-center'>
+        <Button asChild className='m-4'>
           <Link
             href={`/multisig/${requestDetails.multiSigAddress}/requests`}
             onClick={() => setSelectedMultiSigTransactionRequest(null)}

--- a/src/components/multiSigDetails/UserOpRequestCard.stories.tsx
+++ b/src/components/multiSigDetails/UserOpRequestCard.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import type { StoryFn, Meta } from '@storybook/react'
+
+import UserOpRequestCard from './UserOpRequestCard'
+import { MultiSigTransactionRequest } from '../../models/MultiSigs'
+
+const meta: Meta<typeof UserOpRequestCard> = {
+  title: 'MultiSig/UserOpRequestCard',
+  component: UserOpRequestCard
+}
+
+export default meta
+
+const sampleRequest: MultiSigTransactionRequest = {
+  id: '00000000-0000-0000-0000-000000000000',
+  multiSigAddress: '0x2222222222222222222222222222222222222222',
+  description: 'Send 0.001 ETH via Account Abstraction',
+  submitter: '0x2222222222222222222222222222222222222222',
+  signatures: ['0x'],
+  ownerSigners: ['0x2222222222222222222222222222222222222222'],
+  dateSubmitted: new Date().toISOString(),
+  dateExecuted: '',
+  isActive: true,
+  isExecuted: false,
+  isCancelled: false,
+  isConfirmed: false,
+  isSuccessful: false,
+  request: {
+    to: '0x3333333333333333333333333333333333333333',
+    value: '1000000000000000',
+    data: '0x',
+    txnGas: '35000',
+    signatures: '0x',
+    mode: 'userop',
+    userOpHash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+    userOpSigningHash: '0x2222222222222222222222222222222222222222222222222222222222222222',
+    bundlerUrl: 'https://api.pimlico.io/v2/sepolia/rpc'
+  }
+}
+
+export const Basic: StoryFn<typeof UserOpRequestCard> = (args: React.ComponentProps<typeof UserOpRequestCard>) => (
+  <UserOpRequestCard {...args} />
+)
+Basic.args = {
+  request: sampleRequest,
+  threshold: 2,
+  onDelete: () => undefined,
+  onReset: () => undefined
+}

--- a/src/components/multiSigDetails/UserOpRequestCard.tsx
+++ b/src/components/multiSigDetails/UserOpRequestCard.tsx
@@ -1,0 +1,216 @@
+import React, { Fragment } from 'react'
+import Link from 'next/link'
+import { useAccount, useChainId, useChains } from 'wagmi'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+
+import SubmitUserOpRequest from '../buttons/SubmitUserOpRequest'
+import SignUserOp from '../buttons/SignUserOp'
+import ApproveUserOpRequest from '../buttons/ApproveUserOpRequest'
+import RevokeUserOpApproval from '../buttons/RevokeUserOpApproval'
+import useMultiSigDetails from '../../hooks/useMultiSigDetails'
+import useAdvancedFeatures from '../../hooks/useAdvancedFeatures'
+import useEntryPointNonce from '../../hooks/useEntryPointNonce'
+import useUserOpApprovalState from '../../hooks/useUserOpApprovalState'
+import useBundlerConfig from '../../states/bundlerConfig'
+import { MultiSigTransactionRequest } from '../../models/MultiSigs'
+
+interface UserOpRequestCardProps {
+  request: MultiSigTransactionRequest
+  threshold: number
+  onDelete: () => void
+  onReset: () => void
+}
+
+// Dedicated card for a UserOp request. The standard request detail view
+// already covers the multisig path; this card mirrors its layout but uses
+// personal_sign votes, on-chain approveHash(userOpSigningHash), and the
+// bundler-submit flow.
+const UserOpRequestCard: React.FC<UserOpRequestCardProps> = ({ request, threshold, onDelete, onReset }) => {
+  const { address } = useAccount()
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const explorerUrl = chain?.blockExplorers?.default?.url
+  const { multiSigDetails } = useMultiSigDetails(request.multiSigAddress, address || '0x')
+  const { supportsAdvanced, entryPoint } = useAdvancedFeatures(request.multiSigAddress)
+  const { nonce: entryPointNonce } = useEntryPointNonce(entryPoint, request.multiSigAddress)
+  const userOpSigningHash = request.request.userOpSigningHash
+  const { approvedOwners, refetchApprovals } = useUserOpApprovalState(request.multiSigAddress, userOpSigningHash)
+  const getBundlerUrl = useBundlerConfig((s) => s.getBundlerUrl)
+  const getPaymasterUrl = useBundlerConfig((s) => s.getPaymasterUrl)
+  const cfgBundlerUrl = chainId != null ? getBundlerUrl(chainId) : undefined
+  const cfgPaymasterUrl = chainId != null ? getPaymasterUrl(chainId) : undefined
+  const bundlerUrl = request.request.bundlerUrl ?? cfgBundlerUrl
+  const paymasterUrl = request.request.paymasterUrl ?? cfgPaymasterUrl
+
+  const signerSet = new Set(request.ownerSigners.map((s) => s.toLowerCase()))
+  const approverSet = new Set(approvedOwners.map((s) => s.toLowerCase()))
+  const combined = new Set([...signerSet, ...approverSet])
+  const hasSigned = address != null && signerSet.has(address.toLowerCase())
+  const hasApproved = address != null && approverSet.has(address.toLowerCase())
+  const thresholdReached = combined.size >= threshold
+  const receipt = request.request.userOpReceipt
+
+  const row = (label: string, value: React.ReactNode) => (
+    <div key={label} className='flex flex-wrap items-center gap-2'>
+      <span className='px-2 pt-2 text-xl font-bold text-foreground'>{label}</span>
+      <span className='px-2 pt-2 text-lg font-bold text-foreground'>{value}</span>
+    </div>
+  )
+
+  if (multiSigDetails == null) return null
+
+  return (
+    <Fragment>
+      <div className='mt-4 rounded-lg border border-border p-4'>
+        {row('Description', request.description)}
+        {row('Submitted date', new Date(Number(request.dateSubmitted)).toLocaleDateString())}
+        {row('Target', request.request.to)}
+        <div className='flex flex-wrap items-start gap-2'>
+          <span className='px-2 pt-2 text-xl font-bold text-foreground'>Data</span>
+          <Textarea readOnly defaultValue={request.request.data} className='min-h-[80px] flex-1' />
+        </div>
+        {row('Value', request.request.value)}
+        {row('Tx. Gas', request.request.txnGas)}
+        {row('Mode', 'UserOp via bundler (ERC-4337)')}
+        {supportsAdvanced && entryPoint != null && row('EntryPoint', entryPoint)}
+        {entryPointNonce != null && row('EntryPoint nonce', entryPointNonce.toString())}
+        {request.request.userOpHash != null && (
+          <div className='flex flex-wrap items-start gap-2 px-2 pt-2'>
+            <span className='text-xl font-bold text-foreground'>UserOp hash</span>
+            <span className='break-all font-mono text-sm text-foreground'>{request.request.userOpHash}</span>
+          </div>
+        )}
+        {userOpSigningHash != null && (
+          <div className='flex flex-wrap items-start gap-2 px-2 pt-2'>
+            <span className='text-xl font-bold text-foreground'>UserOp signing hash</span>
+            <span className='break-all font-mono text-sm text-foreground'>{userOpSigningHash}</span>
+          </div>
+        )}
+        {row(
+          'Approvals / Threshold',
+          `${combined.size} / ${threshold} (${signerSet.size} personal_sign, ${approverSet.size} on-chain)`
+        )}
+        {bundlerUrl != null && bundlerUrl !== '' && row('Bundler', bundlerUrl)}
+        {paymasterUrl != null && paymasterUrl !== '' && row('Paymaster', paymasterUrl)}
+        {receipt != null && (
+          <Fragment>
+            {row(
+              'Bundled tx',
+              <span>
+                {explorerUrl != null ? (
+                  <a
+                    href={`${explorerUrl}/tx/${receipt.txHash}`}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    className='break-all font-mono text-sm text-foreground underline'
+                  >
+                    {receipt.txHash}
+                  </a>
+                ) : (
+                  <span className='break-all font-mono text-sm text-foreground'>{receipt.txHash}</span>
+                )}
+              </span>
+            )}
+            {row(
+              'Status',
+              receipt.success ? 'success' : `failed${receipt.reason != null ? ` (${receipt.reason})` : ''}`
+            )}
+            {row('Block', receipt.blockNumber)}
+          </Fragment>
+        )}
+        {request.isExecuted ? (
+          <div className='px-2 pt-2 text-xl font-bold text-primary'>
+            This UserOp request has been executed
+            {request.dateExecuted != null && ` on ${new Date(request.dateExecuted).toLocaleDateString()}`}.
+          </div>
+        ) : (
+          <Fragment>
+            {thresholdReached && bundlerUrl != null && bundlerUrl !== '' && entryPoint != null && (
+              <div className='flex flex-wrap items-center gap-2'>
+                <span className='px-2 pt-2 text-xl font-bold text-foreground'>Send to bundler</span>
+                <SubmitUserOpRequest
+                  wallet={request.multiSigAddress}
+                  entryPoint={entryPoint}
+                  bundlerUrl={bundlerUrl}
+                  paymasterUrl={paymasterUrl}
+                  walletVersion={multiSigDetails.version}
+                  requestDetails={request}
+                  existingRequestId={request.id}
+                />
+              </div>
+            )}
+            {!thresholdReached && (
+              <div className='flex flex-wrap items-center gap-2'>
+                <span className='px-2 pt-2 text-xl font-bold text-foreground'>Sign this UserOp</span>
+                {hasSigned ? (
+                  <span className='px-2 pt-2 text-xl font-bold text-primary'>You already signed this UserOp</span>
+                ) : hasApproved ? (
+                  <span className='px-2 pt-2 text-lg font-bold text-muted-foreground'>
+                    You approved on-chain; a signature would be a duplicate vote
+                  </span>
+                ) : entryPoint != null ? (
+                  <SignUserOp
+                    wallet={request.multiSigAddress}
+                    entryPoint={entryPoint}
+                    nonce={entryPointNonce}
+                    bundlerUrl={bundlerUrl}
+                    paymasterUrl={paymasterUrl}
+                    description={request.description}
+                    args={request.request}
+                    requestDetails={request}
+                    existingRequestId={request.id}
+                  />
+                ) : (
+                  <span className='px-2 pt-2 text-lg text-muted-foreground'>
+                    EntryPoint is unknown for this wallet — re-sync the wallet.
+                  </span>
+                )}
+              </div>
+            )}
+            {userOpSigningHash != null && entryPoint != null && !hasApproved && !hasSigned && (
+              <div className='flex flex-wrap items-center gap-2'>
+                <span className='px-2 pt-2 text-xl font-bold text-foreground'>Or approve on-chain</span>
+                <ApproveUserOpRequest
+                  multiSigAddress={request.multiSigAddress}
+                  userOpSigningHash={userOpSigningHash}
+                  onApproved={() => refetchApprovals()}
+                />
+              </div>
+            )}
+            {userOpSigningHash != null && hasApproved && (
+              <div className='flex flex-wrap items-center gap-2'>
+                <span className='px-2 pt-2 text-xl font-bold text-foreground'>Withdraw your approval</span>
+                <RevokeUserOpApproval
+                  multiSigAddress={request.multiSigAddress}
+                  userOpSigningHash={userOpSigningHash}
+                  onRevoked={() => refetchApprovals()}
+                />
+              </div>
+            )}
+            <div className='flex flex-wrap items-center gap-2'>
+              <span className='px-2 pt-2 text-xl font-bold text-foreground'>Reset signatures</span>
+              <Button variant='outline' className='mx-2 mt-2' onClick={onReset}>
+                Reset
+              </Button>
+            </div>
+            <div className='flex flex-wrap items-center gap-2'>
+              <span className='px-2 pt-2 text-xl font-bold text-foreground'>Delete this request</span>
+              <Button variant='destructive' className='mx-2 mt-2' onClick={onDelete}>
+                Delete
+              </Button>
+            </div>
+          </Fragment>
+        )}
+      </div>
+      <div className='flex justify-center'>
+        <Button asChild className='m-4'>
+          <Link href={`/multisig/${request.multiSigAddress}/requests`}>View a different request</Link>
+        </Button>
+      </div>
+    </Fragment>
+  )
+}
+
+export default UserOpRequestCard

--- a/src/constants/abi/entryPoint.ts
+++ b/src/constants/abi/entryPoint.ts
@@ -1,7 +1,8 @@
 // Minimal surface of the canonical ERC-4337 EntryPoint v0.7
 // (0x0000000071727De22E5E9d8BDe0dFeC0CEB6a7d7, identical on every chain):
-// just the deposit bookkeeping the app needs to show and prefund a wallet's
-// gas balance. The full EntryPoint ABI is not shipped by mymultisig-contract.
+// just the deposit + UserOp bookkeeping the app needs to show, prefund, and
+// submit through a bundler. The full EntryPoint ABI is not shipped by
+// mymultisig-contract, so this is the entire app-facing surface.
 export const EntryPointAbi = [
   {
     inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
@@ -15,6 +16,88 @@ export const EntryPointAbi = [
     name: 'depositTo',
     outputs: [],
     stateMutability: 'payable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'withdrawAddress', type: 'address' },
+      { internalType: 'uint256', name: 'withdrawAmount', type: 'uint256' }
+    ],
+    name: 'withdrawTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'sender', type: 'address' },
+      { internalType: 'uint192', name: 'key', type: 'uint192' }
+    ],
+    name: 'getNonce',
+    outputs: [{ internalType: 'uint256', name: 'nonce', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'getDepositInfo',
+    outputs: [
+      { internalType: 'uint256', name: 'deposit', type: 'uint256' },
+      { internalType: 'bool', name: 'staked', type: 'bool' },
+      { internalType: 'uint112', name: 'stake', type: 'uint112' },
+      { internalType: 'uint32', name: 'unstakeDelaySec', type: 'uint32' },
+      { internalType: 'uint48', name: 'withdrawTime', type: 'uint48' }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'sender', type: 'address' },
+          { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+          { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+          { internalType: 'bytes', name: 'callData', type: 'bytes' },
+          { internalType: 'bytes32', name: 'accountGasLimits', type: 'bytes32' },
+          { internalType: 'uint256', name: 'preVerificationGas', type: 'uint256' },
+          { internalType: 'bytes32', name: 'gasFees', type: 'bytes32' },
+          { internalType: 'bytes', name: 'paymasterAndData', type: 'bytes' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' }
+        ],
+        internalType: 'struct PackedUserOperation',
+        name: 'userOp',
+        type: 'tuple'
+      }
+    ],
+    name: 'getUserOpHash',
+    outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'sender', type: 'address' },
+          { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+          { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+          { internalType: 'bytes', name: 'callData', type: 'bytes' },
+          { internalType: 'bytes32', name: 'accountGasLimits', type: 'bytes32' },
+          { internalType: 'uint256', name: 'preVerificationGas', type: 'uint256' },
+          { internalType: 'bytes32', name: 'gasFees', type: 'bytes32' },
+          { internalType: 'bytes', name: 'paymasterAndData', type: 'bytes' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' }
+        ],
+        internalType: 'struct PackedUserOperation[]',
+        name: 'ops',
+        type: 'tuple[]'
+      },
+      { internalType: 'address payable', name: 'beneficiary', type: 'address' }
+    ],
+    name: 'handleOps',
+    outputs: [],
+    stateMutability: 'nonpayable',
     type: 'function'
   }
 ] as const

--- a/src/hooks/useApproveUserOpHash.ts
+++ b/src/hooks/useApproveUserOpHash.ts
@@ -1,0 +1,25 @@
+import { useChainId, useChains } from 'wagmi'
+import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
+
+import { useNotification } from './notifications'
+import useFinalizeTransaction from './useFinalizeTransaction'
+
+// On-chain pre-approval of a UserOp digest. Owners call
+// `wallet.approveHash(userOpSigningHash)` to count toward the threshold
+// without producing an off-chain signature. Idempotent per (owner, hash).
+const useApproveUserOpHash = (multiSigAddress: `0x${string}`, userOpSigningHash: `0x${string}` | undefined) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { notificationInfo, notificationError, notificationSuccess } = useNotification()
+  const config = {
+    chainId: chain?.id,
+    address: multiSigAddress,
+    abi: MyMultiSigExtended,
+    functionName: 'approveHash' as const,
+    args: [userOpSigningHash ?? '0x'] as const
+  }
+  return useFinalizeTransaction(config, notificationInfo, notificationSuccess, notificationError)
+}
+
+export default useApproveUserOpHash

--- a/src/hooks/useEntryPointDeposit.ts
+++ b/src/hooks/useEntryPointDeposit.ts
@@ -4,7 +4,8 @@ import { EntryPointAbi } from '../constants/abi/entryPoint'
 
 // ERC-4337 gas deposit for a 0.5.0 Extended wallet: bundlers draw the fees of
 // a UserOperation from the wallet's balance held inside the EntryPoint.
-// Anyone can prefund it via the payable depositTo(wallet).
+// Anyone can prefund it via the payable depositTo(wallet). The owner can
+// withdraw the deposit back to themselves via `withdrawTo`.
 const useEntryPointDeposit = (entryPoint: `0x${string}` | undefined, multiSigAddress: `0x${string}`) => {
   const chainId = useChainId()
   const chains = useChains()
@@ -32,9 +33,22 @@ const useEntryPointDeposit = (entryPoint: `0x${string}` | undefined, multiSigAdd
     refetch()
   }
 
+  const withdraw = async (recipient: `0x${string}`, amountWei: bigint) => {
+    if (entryPoint == null) return
+    await writeContractAsync({
+      chainId: chain?.id,
+      address: entryPoint,
+      abi: EntryPointAbi,
+      functionName: 'withdrawTo',
+      args: [recipient, amountWei]
+    })
+    refetch()
+  }
+
   return {
     depositBalance: depositBalance != null ? BigInt(depositBalance) : undefined,
     deposit,
+    withdraw,
     isPending,
     refetch
   }

--- a/src/hooks/useEntryPointNonce.ts
+++ b/src/hooks/useEntryPointNonce.ts
@@ -1,0 +1,29 @@
+import { useChainId, useChains, useReadContract } from 'wagmi'
+
+import { EntryPointAbi } from '../constants/abi/entryPoint'
+
+// ERC-4337 v0.7 2D nonce for a wallet. The contract reads it via
+// `EntryPoint.getNonce(sender, 192)` (192 = the 0.7 default key, same on
+// every chain). The wallet's own `txnNonce` is unrelated — it tracks the
+// multisig transaction path, not the UserOp path.
+const useEntryPointNonce = (entryPoint: `0x${string}` | undefined, wallet: `0x${string}`) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { data, refetch, isLoading, isError } = useReadContract({
+    chainId: chain?.id,
+    address: entryPoint ?? '0x',
+    abi: EntryPointAbi,
+    functionName: 'getNonce',
+    args: [wallet, 192n],
+    query: { enabled: entryPoint != null && wallet !== '0x', retry: false }
+  })
+  return {
+    nonce: data != null ? BigInt(data as bigint) : undefined,
+    refetch,
+    isLoading,
+    isError
+  }
+}
+
+export default useEntryPointNonce

--- a/src/hooks/useRevokeUserOpHash.ts
+++ b/src/hooks/useRevokeUserOpHash.ts
@@ -1,0 +1,25 @@
+import { useChainId, useChains } from 'wagmi'
+import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
+
+import { useNotification } from './notifications'
+import useFinalizeTransaction from './useFinalizeTransaction'
+
+// Withdraws the connected owner's on-chain approval of a UserOp digest.
+// Self-only — the wallet reverts with NotApproved() for a hash the owner
+// never approved. 0.5.0 wallets only.
+const useRevokeUserOpHash = (multiSigAddress: `0x${string}`, userOpSigningHash: `0x${string}` | undefined) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { notificationInfo, notificationError, notificationSuccess } = useNotification()
+  const config = {
+    chainId: chain?.id,
+    address: multiSigAddress,
+    abi: MyMultiSigExtended,
+    functionName: 'revokeApproval' as const,
+    args: [userOpSigningHash ?? '0x'] as const
+  }
+  return useFinalizeTransaction(config, notificationInfo, notificationSuccess, notificationError)
+}
+
+export default useRevokeUserOpHash

--- a/src/hooks/useSendUserOp.ts
+++ b/src/hooks/useSendUserOp.ts
@@ -1,0 +1,186 @@
+import { useState } from 'react'
+import { useChainId, useChains } from 'wagmi'
+
+import { useNotification } from './notifications'
+import { MultiSigTransactionRequest, UserOpReceipt } from '../models/MultiSigs'
+import useMultiSigs from '../states/multiSigs'
+import { patchMultiSigRequest } from '../utils'
+import {
+  BundlerRpcError,
+  estimateUserOperationGas,
+  sendUserOperation,
+  waitForUserOperationReceipt
+} from '../utils/bundler'
+import { pmGetPaymasterData } from '../utils/paymaster'
+import decodeContractError from '../utils/decodeContractError'
+import {
+  PackedUserOp,
+  packAccountGasLimits,
+  packUserOpSignatures,
+  unpackAccountGasLimits,
+  userOpFromJson,
+  userOpToJson
+} from '../utils/userOp'
+import { toast } from 'sonner'
+
+// Sends a fully-signed UserOp to the bundler. The threshold must already be
+// reached (the caller enforces it). The hook tries a paymaster first if
+// configured, then eth_estimateUserOperationGas to refine the gas fields,
+// then eth_sendUserOperation, then polls eth_getUserOperationReceipt.
+//
+// All terminal states (success, failure, error) are persisted to Neon +
+// Zustand so the request detail view can show the latest state on reload.
+
+type SendResult =
+  | { status: 'idle' }
+  | { status: 'estimating' }
+  | { status: 'sending' }
+  | { status: 'submitted'; userOpHash: `0x${string}` }
+  | { status: 'polling'; userOpHash: `0x${string}` }
+  | { status: 'mined'; userOpHash: `0x${string}`; receipt: UserOpReceipt }
+  | { status: 'failed'; reason: string; userOpHash?: `0x${string}`; receipt?: UserOpReceipt }
+
+const useSendUserOp = ({
+  request,
+  entryPoint,
+  bundlerUrl,
+  paymasterUrl,
+  walletVersion
+}: {
+  request: MultiSigTransactionRequest
+  entryPoint: `0x${string}`
+  bundlerUrl: string
+  paymasterUrl?: string
+  walletVersion: string | undefined
+}): { state: SendResult; send: () => Promise<void> } => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { updateMultiSigTransactionRequest } = useMultiSigs()
+  const { notificationError } = useNotification()
+  const [state, setState] = useState<SendResult>({ status: 'idle' })
+
+  const persisted = (patch: Partial<MultiSigTransactionRequest>) => {
+    if (chain == null) return
+    const next: MultiSigTransactionRequest = { ...request, ...patch }
+    patchMultiSigRequest(request.id, patch).then(() => {
+      updateMultiSigTransactionRequest(request.id, next)
+    })
+  }
+
+  const send = async () => {
+    if (request.request.userOpJson == null || request.request.userOpHash == null) {
+      setState({ status: 'failed', reason: 'Request is missing the UserOp payload; rebuild and re-sign it.' })
+      return
+    }
+    const baseOp = userOpFromJson(request.request.userOpJson)
+    const signature = packUserOpSignatures(walletVersion, request.ownerSigners, request.signatures)
+    const op: PackedUserOp = { ...baseOp, signature }
+
+    try {
+      setState({ status: 'estimating' })
+      toast.info('Estimating UserOp gas...')
+
+      let effectivePaymasterAndData = op.paymasterAndData
+      const initialUnpacked = unpackAccountGasLimits(op.accountGasLimits)
+      let effectiveVerificationGasLimit = initialUnpacked.verificationGasLimit
+      let effectiveCallGasLimit = initialUnpacked.callGasLimit
+
+      if (paymasterUrl != null && paymasterUrl !== '') {
+        try {
+          const pm = await pmGetPaymasterData(paymasterUrl, { userOp: op, entryPoint })
+          effectivePaymasterAndData = pm.paymasterAndData
+          if (pm.verificationGasLimit != null) effectiveVerificationGasLimit = BigInt(pm.verificationGasLimit)
+          if (pm.callGasLimit != null) effectiveCallGasLimit = BigInt(pm.callGasLimit)
+        } catch (pmError) {
+          console.warn('paymaster pm_getPaymasterData failed; falling back to wallet deposit', pmError)
+        }
+      }
+
+      let estimatedOp: PackedUserOp = {
+        ...op,
+        paymasterAndData: effectivePaymasterAndData,
+        accountGasLimits: packAccountGasLimits({
+          verificationGasLimit: effectiveVerificationGasLimit.toString(),
+          callGasLimit: effectiveCallGasLimit.toString()
+        })
+      }
+
+      try {
+        const estimate = await estimateUserOperationGas(bundlerUrl, estimatedOp, entryPoint)
+        const call = BigInt(estimate.callGasLimit)
+        const verify = BigInt(estimate.verificationGasLimit)
+        const pre = BigInt(estimate.preVerificationGas)
+        estimatedOp = {
+          ...estimatedOp,
+          preVerificationGas: pre,
+          accountGasLimits: packAccountGasLimits({
+            verificationGasLimit: verify.toString(),
+            callGasLimit: call.toString()
+          }),
+          ...(estimate.paymasterAndData != null ? { paymasterAndData: estimate.paymasterAndData } : {})
+        }
+      } catch (estimateError) {
+        console.warn('Bundler gas estimation failed; sending with the configured defaults', estimateError)
+      }
+
+      // Persist the final UserOp payload (sans signature) so a refresh shows
+      // the exact op the bundler saw.
+      persisted({
+        request: { ...request.request, userOpJson: userOpToJson({ ...estimatedOp, signature: '0x' }) }
+      })
+
+      setState({ status: 'sending' })
+      toast.info('Sending UserOp to the bundler...')
+      const userOpHash = await sendUserOperation(bundlerUrl, estimatedOp, entryPoint)
+      persisted({ request: { ...request.request, userOpHash } })
+
+      setState({ status: 'submitted', userOpHash })
+      setState({ status: 'polling', userOpHash })
+      toast.info('Waiting for the bundler to mine the UserOp...')
+      const receipt = await waitForUserOperationReceipt(bundlerUrl, userOpHash, { timeout: 180_000 })
+      const mapped: UserOpReceipt = {
+        userOpHash: receipt.userOpHash,
+        txHash: receipt.receipt.transactionHash,
+        blockHash: receipt.receipt.blockHash,
+        blockNumber: receipt.receipt.blockNumber,
+        success: receipt.success,
+        ...(receipt.reason != null ? { reason: receipt.reason } : {})
+      }
+      persisted({
+        request: { ...request.request, userOpReceipt: mapped },
+        isExecuted: true,
+        isSuccessful: receipt.success,
+        dateExecuted: new Date().toISOString()
+      })
+
+      if (receipt.success) {
+        setState({ status: 'mined', userOpHash, receipt: mapped })
+      } else {
+        const reason = receipt.reason ?? 'The bundler mined the UserOp but the inner call reverted.'
+        toast.error('Bundler rejected the UserOp', { description: reason })
+        setState({ status: 'failed', reason, userOpHash, receipt: mapped })
+      }
+    } catch (err) {
+      const decoded = decodeContractError(err)
+      const reason =
+        decoded ??
+        (err instanceof BundlerRpcError
+          ? `Bundler rejected: ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : 'Send failed')
+      console.error('UserOp send failed', err)
+      notificationError()
+      setState({ status: 'failed', reason })
+    }
+  }
+
+  return { state, send }
+}
+
+// Make the unpacker available for callers that want to inspect the bundled
+// gas fields (e.g. the receipt card).
+export { unpackAccountGasLimits }
+
+export default useSendUserOp

--- a/src/hooks/useUserOpApprovalState.ts
+++ b/src/hooks/useUserOpApprovalState.ts
@@ -1,0 +1,28 @@
+import { useChainId, useChains, useReadContract } from 'wagmi'
+
+import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
+
+// Reads the on-chain approvers of a UserOp digest (the
+// `userOpSigningHash(userOpHash)` owners sign). Mirrors the standard
+// request's `useRequestApprovalState` but indexed on the UserOp digest
+// rather than the EIP-712 transaction hash.
+const useUserOpApprovalState = (multiSigAddress: `0x${string}`, userOpSigningHash: `0x${string}` | undefined) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const enabled = userOpSigningHash != null && userOpSigningHash !== '0x' && multiSigAddress !== '0x'
+  const { data, refetch } = useReadContract({
+    chainId: chain?.id,
+    address: multiSigAddress,
+    abi: MyMultiSigExtended,
+    functionName: 'getApprovedOwners',
+    args: [userOpSigningHash ?? '0x'],
+    query: { enabled, retry: false }
+  })
+  return {
+    approvedOwners: ((data as string[] | undefined) ?? []).map(String),
+    refetchApprovals: refetch
+  }
+}
+
+export default useUserOpApprovalState

--- a/src/hooks/useUserOpReceipt.ts
+++ b/src/hooks/useUserOpReceipt.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+
+import { UserOpReceipt } from '../models/MultiSigs'
+import { getUserOperationReceipt } from '../utils/bundler'
+
+// Poll a bundler for a UserOp's receipt. The hook polls on a fixed interval
+// until `success` is set or the timeout elapses, then returns the receipt
+// (or null on timeout). Caller decides what to do with success/failure.
+const useUserOpReceipt = (
+  bundlerUrl: string | undefined,
+  userOpHash: `0x${string}` | undefined,
+  {
+    timeout = 120_000,
+    interval = 2_000,
+    enabled = true
+  }: { timeout?: number; interval?: number; enabled?: boolean } = {}
+) => {
+  const [receipt, setReceipt] = useState<UserOpReceipt | null>(null)
+  const [isPolling, setIsPolling] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (!enabled || bundlerUrl == null || userOpHash == null) return
+    let cancelled = false
+    const deadline = Date.now() + timeout
+    setIsPolling(true)
+    setError(null)
+    const poll = async () => {
+      if (cancelled) return
+      if (Date.now() > deadline) {
+        setIsPolling(false)
+        setError(new Error(`Bundler receipt for ${userOpHash} did not arrive within ${timeout}ms`))
+        return
+      }
+      try {
+        const r = await getUserOperationReceipt(bundlerUrl, userOpHash)
+        if (cancelled) return
+        if (r != null) {
+          const mapped: UserOpReceipt = {
+            userOpHash: r.userOpHash,
+            txHash: r.receipt.transactionHash,
+            blockHash: r.receipt.blockHash,
+            blockNumber: r.receipt.blockNumber,
+            success: r.success,
+            ...(r.reason != null ? { reason: r.reason } : {})
+          }
+          setReceipt(mapped)
+          setIsPolling(false)
+          return
+        }
+      } catch (err) {
+        if (cancelled) return
+        setError(err instanceof Error ? err : new Error(String(err)))
+      }
+      setTimeout(() => {
+        void poll()
+      }, interval)
+    }
+    void poll()
+    return () => {
+      cancelled = true
+      setIsPolling(false)
+    }
+  }, [bundlerUrl, userOpHash, enabled, timeout, interval])
+
+  return { receipt, isPolling, error }
+}
+
+export default useUserOpReceipt

--- a/src/hooks/useUserOpSigning.ts
+++ b/src/hooks/useUserOpSigning.ts
@@ -1,0 +1,230 @@
+import { useEffect, useState } from 'react'
+import { useAccount, useChainId, useChains, useReadContract, useSignMessage } from 'wagmi'
+import { v4 } from 'uuid'
+
+import { EntryPointAbi } from '../constants/abi/entryPoint'
+import MyMultiSigExtended from 'mymultisig-contract/abi/MyMultiSigExtended.json'
+import { useNotificationError, useNotificationSuccess } from './notifications'
+import useMultiSigDetails from './useMultiSigDetails'
+import { MultiSigExecTransactionArgs, MultiSigTransactionRequest } from '../models/MultiSigs'
+import useMultiSigs from '../states/multiSigs'
+import { addMultiSigRequest, patchMultiSigRequest } from '../utils'
+import {
+  DEFAULT_USEROP_GAS,
+  buildPackedUserOp,
+  encodeUserOpCallData,
+  packUserOpSignatures,
+  userOpToJson
+} from '../utils/userOp'
+
+// UserOp signing: builds the PackedUserOperation from the request's
+// (to, value, data, gas) triple, reads the EntryPoint nonce, computes
+// userOpHash + userOpSigningHash, and exposes a `sign()` action that uses
+// personal_sign over `userOpSigningHash` (the EIP-191 wrap the wallet's
+// `validateUserOp` verifies). Each owner accumulates a vote in the same
+// `request.signatures` / `request.ownerSigners` arrays the multisig path
+// uses, and the combined signature is the same blob the contract consumes.
+
+const useUserOpSigning = ({
+  wallet: walletAddress,
+  entryPoint,
+  args,
+  description,
+  existingRequest,
+  existingRequestId,
+  nonce,
+  bundlerUrl,
+  paymasterUrl,
+  userOpGas = DEFAULT_USEROP_GAS
+}: {
+  wallet: `0x${string}`
+  entryPoint: `0x${string}`
+  args: MultiSigExecTransactionArgs
+  description: string
+  existingRequest?: MultiSigTransactionRequest
+  existingRequestId?: string
+  nonce: bigint | undefined
+  bundlerUrl?: string
+  paymasterUrl?: string
+  userOpGas?: MultiSigExecTransactionArgs['userOpGas']
+}) => {
+  const chainId = useChainId()
+  const chains = useChains()
+  const chain = chains.find((c) => c.id === chainId)
+  const { address } = useAccount()
+  const { addMultiSigTransactionRequest, updateMultiSigTransactionRequest } = useMultiSigs()
+  const { data: multiSigDetails } = useMultiSigDetails(walletAddress, address || '0x')
+  const walletVersion = multiSigDetails != null ? String(multiSigDetails[1]) : undefined
+  const [dataAdded, setDataAdded] = useState(false)
+  const notificationError = useNotificationError('Error signing UserOp', 'There was an error signing the UserOp.')
+  const notificationSuccess = useNotificationSuccess('Signed UserOp', 'You signed the UserOp successfully.')
+
+  const ready = nonce != null && entryPoint != null && walletAddress !== '0x'
+  const value = isUintOrHex(args.value) ? BigInt(args.value) : 0n
+  const callData = ready ? encodeUserOpCallData({ wallet: walletAddress, to: args.to, value, data: args.data }) : '0x'
+  const userOp = ready
+    ? buildPackedUserOp({
+        sender: walletAddress,
+        nonce: nonce as bigint,
+        callData,
+        gas: userOpGas as NonNullable<typeof userOpGas>,
+        paymasterAndData: '0x'
+      })
+    : null
+
+  // userOpHash is the EntryPoint's view-call result and binds the full op;
+  // userOpSigningHash is the EIP-191 wrap the wallet returns so owners can
+  // personal_sign it via any wallet.
+  const { data: userOpHash } = useReadContract({
+    chainId: chain?.id,
+    address: entryPoint,
+    abi: EntryPointAbi,
+    functionName: 'getUserOpHash',
+    args: [
+      userOp
+        ? {
+            sender: userOp.sender,
+            nonce: userOp.nonce,
+            initCode: userOp.initCode,
+            callData: userOp.callData,
+            accountGasLimits: userOp.accountGasLimits,
+            preVerificationGas: userOp.preVerificationGas,
+            gasFees: userOp.gasFees,
+            paymasterAndData: userOp.paymasterAndData,
+            signature: userOp.signature
+          }
+        : {
+            sender: '0x0000000000000000000000000000000000000000',
+            nonce: 0n,
+            initCode: '0x',
+            callData: '0x',
+            accountGasLimits: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            preVerificationGas: 0n,
+            gasFees: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            paymasterAndData: '0x',
+            signature: '0x'
+          }
+    ],
+    query: { enabled: ready, retry: false }
+  })
+  const { data: userOpSigningHash } = useReadContract({
+    chainId: chain?.id,
+    address: walletAddress,
+    abi: MyMultiSigExtended,
+    functionName: 'userOpSigningHash',
+    args: [((userOpHash as `0x${string}` | undefined) ?? '0x') as `0x${string}`],
+    query: { enabled: userOpHash != null, retry: false }
+  })
+
+  const v = isUintOrHex(args.value) ? args.value : '0'
+  const g = isUintOrHex(args.txnGas) ? args.txnGas : '0'
+  const valueAndGasCheck = v !== '' && g !== ''
+
+  const { data, isError, isPending, isSuccess, error, signMessage, reset } = useSignMessage()
+
+  useEffect(() => {
+    if (error) notificationError()
+  }, [error, notificationError])
+
+  useEffect(() => {
+    if (isSuccess && data) notificationSuccess()
+  }, [isSuccess, data, notificationSuccess])
+
+  useEffect(() => {
+    if (isSuccess && data && chain && !dataAdded && userOp && userOpHash != null && userOpSigningHash != null) {
+      setDataAdded(true)
+      const allSigners = existingRequest ? [...existingRequest.ownerSigners, address || '0x'] : [address || '0x']
+      const allSignatures = existingRequest ? [...existingRequest.signatures, data || '0x'] : [data || '0x']
+      const combined = packUserOpSignatures(walletVersion, allSigners, allSignatures)
+      const persistedUserOpJson = existingRequest?.request.userOpJson ?? userOpToJson(userOp)
+      const dataToAdd: MultiSigTransactionRequest = existingRequest
+        ? {
+            ...existingRequest,
+            request: {
+              ...existingRequest.request,
+              signatures: combined,
+              mode: 'userop',
+              userOpHash: userOpHash as `0x${string}`,
+              userOpSigningHash: userOpSigningHash as `0x${string}`,
+              userOpJson: { ...persistedUserOpJson, signature: '0x' },
+              userOpNonce: persistedUserOpJson.nonce,
+              userOpGas: userOpGas as MultiSigExecTransactionArgs['userOpGas'],
+              ...(bundlerUrl != null ? { bundlerUrl } : {}),
+              ...(paymasterUrl != null ? { paymasterUrl } : {})
+            },
+            signatures: allSignatures,
+            ownerSigners: allSigners as `0x${string}`[]
+          }
+        : {
+            id: v4(),
+            multiSigAddress: walletAddress,
+            request: {
+              ...args,
+              signatures: combined,
+              mode: 'userop',
+              userOpHash: userOpHash as `0x${string}`,
+              userOpSigningHash: userOpSigningHash as `0x${string}`,
+              userOpJson: { ...persistedUserOpJson, signature: '0x' },
+              userOpNonce: persistedUserOpJson.nonce,
+              userOpGas: userOpGas as MultiSigExecTransactionArgs['userOpGas'],
+              ...(bundlerUrl != null ? { bundlerUrl } : {}),
+              ...(paymasterUrl != null ? { paymasterUrl } : {})
+            },
+            description,
+            submitter: address || '0x',
+            signatures: [data || '0x'],
+            ownerSigners: [address || '0x'],
+            dateSubmitted: Date.now().toString(),
+            dateExecuted: '',
+            isActive: true,
+            isExecuted: false,
+            isCancelled: false,
+            isConfirmed: false,
+            isSuccessful: false
+          }
+      if (existingRequest && existingRequestId)
+        patchMultiSigRequest(existingRequestId, dataToAdd).then(() => {
+          updateMultiSigTransactionRequest(existingRequest.id, dataToAdd)
+        })
+      else
+        addMultiSigRequest(dataToAdd).then(() => {
+          addMultiSigTransactionRequest(dataToAdd)
+        })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [existingRequest, dataAdded, isSuccess, data, walletAddress, address, chain, args, description])
+
+  return {
+    isPrepareError: !valueAndGasCheck || !ready || userOpHash == null || userOpSigningHash == null,
+    prepareError: !valueAndGasCheck
+      ? 'Invalid value or gas'
+      : !ready
+        ? 'EntryPoint nonce is not yet known'
+        : userOpHash == null
+          ? 'Could not derive the UserOp hash from the EntryPoint'
+          : 'Could not derive the UserOp signing hash from the wallet',
+    data,
+    isError,
+    isPending,
+    isSuccess,
+    error,
+    signMessage: () => {
+      // The owners sign the *inner* userOpHash (the 32-byte EntryPoint
+      // digest) via personal_sign. The wallet's `userOpSigningHash` is the
+      // EIP-191 wrap of that digest, so the resulting signature is over
+      // exactly `userOpSigningHash` — which is what `_checkSignatures` in
+      // `validateUserOp` recovers from.
+      if (ready && userOpHash != null) signMessage({ message: { raw: userOpHash as `0x${string}` } })
+    },
+    reset,
+    // Surfacing the intermediate hashes so the UI can show progress.
+    userOpHash: userOpHash as `0x${string}` | undefined,
+    userOpSigningHash: userOpSigningHash as `0x${string}` | undefined,
+    userOp
+  }
+}
+
+const isUintOrHex = (value: string | undefined): boolean =>
+  value != null && value !== '' && (/^\d+$/.test(value) || /^0x[0-9a-fA-F]+$/.test(value))
+
+export default useUserOpSigning

--- a/src/models/MultiSigs.ts
+++ b/src/models/MultiSigs.ts
@@ -57,6 +57,38 @@ export type BatchResult = {
   returnData: string
 }
 
+// JSON-safe (hex-string) mirror of the EntryPoint v0.7 PackedUserOperation.
+// BigInts go over the wire as `0x`-prefixed hex strings so the request payload
+// survives the JSONB round-trip through Neon + Zustand's localStorage.
+export type PackedUserOpJson = {
+  sender: `0x${string}`
+  nonce: string
+  initCode: `0x${string}`
+  callData: `0x${string}`
+  accountGasLimits: `0x${string}`
+  preVerificationGas: string
+  gasFees: `0x${string}`
+  paymasterAndData: `0x${string}`
+  signature: `0x${string}`
+}
+
+export type UserOpGas = {
+  verificationGasLimit: string
+  callGasLimit: string
+  preVerificationGas: string
+  maxFeePerGas: string
+  maxPriorityFeePerGas: string
+}
+
+export type UserOpReceipt = {
+  userOpHash: `0x${string}`
+  blockHash: `0x${string}`
+  blockNumber: string
+  txHash: `0x${string}`
+  success: boolean
+  reason?: string
+}
+
 export type MultiSigExecTransactionArgs = {
   to: `0x${string}`
   value: string
@@ -78,6 +110,28 @@ export type MultiSigExecTransactionArgs = {
   // 0.5.0 wallets only: batch encoded as multiRequestStrict — atomic, the
   // whole transaction reverts on the first failing step.
   strictBatch?: boolean
+  // 'userop' on 0.5.0 Extended wallets when the request is meant to be
+  // dispatched through a bundler (callData is wallet.execute(...), signatures
+  // are personal_sign over userOpSigningHash). Undefined/'standard' = the
+  // classic execTransaction flow.
+  mode?: 'standard' | 'userop'
+  // ERC-4337 hashes the bundler / contract binds to the request. Both are
+  // kept so the detail view can re-derive approvals on refresh.
+  userOpHash?: `0x${string}`
+  userOpSigningHash?: `0x${string}`
+  // The fully-built PackedUserOperation (signature is filled in at submit
+  // time, not at sign time, so the same slot can be re-signed/replayed).
+  userOpJson?: PackedUserOpJson
+  // The bundler/intent params captured at build time (hex strings). Cheap
+  // to keep here so re-estimating doesn't require a full rebuild.
+  userOpNonce?: string
+  userOpGas?: UserOpGas
+  // The bundler/paymaster URL the creator used, captured per request so a
+  // second owner can verify the same target bundler.
+  bundlerUrl?: string
+  paymasterUrl?: string
+  // Final receipt after a successful send-to-bundler.
+  userOpReceipt?: UserOpReceipt
 }
 
 export type MultiSigTransactionRequest = {

--- a/src/states/bundlerConfig.ts
+++ b/src/states/bundlerConfig.ts
@@ -1,0 +1,57 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+// Per-chain bundler + paymaster URLs the user has configured in the UI. The
+// store is persisted to localStorage so the URLs survive reloads; env vars
+// (`NEXT_PUBLIC_BUNDLER_URL_<chainId>` / `NEXT_PUBLIC_PAYMASTER_URL_<chainId>`)
+// are looked up as a fallback when no override is set.
+
+export type ChainAaConfig = {
+  bundlerUrl?: string
+  paymasterUrl?: string
+}
+
+interface BundlerConfigState {
+  perChain: Record<number, ChainAaConfig>
+  setConfig: (chainId: number, config: ChainAaConfig) => void
+  clearConfig: (chainId: number) => void
+  getConfig: (chainId: number) => ChainAaConfig
+  // Resolves with env fallback.
+  getBundlerUrl: (chainId: number) => string | undefined
+  getPaymasterUrl: (chainId: number) => string | undefined
+}
+
+const envUrl = (chainId: number, kind: 'bundler' | 'paymaster'): string | undefined => {
+  const upper = kind.toUpperCase()
+  const perChain = process.env[`NEXT_PUBLIC_${upper}_URL_${chainId}`]
+  if (perChain != null && perChain !== '') return perChain
+  const generic = process.env[`NEXT_PUBLIC_${upper}_URL`]
+  return generic != null && generic !== '' ? generic : undefined
+}
+
+const useBundlerConfig = create<BundlerConfigState>()(
+  persist(
+    (set, get) => ({
+      perChain: {},
+      setConfig: (chainId, config) =>
+        set((state) => ({
+          perChain: { ...state.perChain, [chainId]: { ...state.perChain[chainId], ...config } }
+        })),
+      clearConfig: (chainId) =>
+        set((state) => {
+          const next = { ...state.perChain }
+          delete next[chainId]
+          return { perChain: next }
+        }),
+      getConfig: (chainId) => get().perChain[chainId] ?? {},
+      getBundlerUrl: (chainId) => get().perChain[chainId]?.bundlerUrl ?? envUrl(chainId, 'bundler'),
+      getPaymasterUrl: (chainId) => get().perChain[chainId]?.paymasterUrl ?? envUrl(chainId, 'paymaster')
+    }),
+    {
+      name: 'mymultisig-aa-config',
+      storage: createJSONStorage(() => localStorage)
+    }
+  )
+)
+
+export default useBundlerConfig

--- a/src/utils/bundler.ts
+++ b/src/utils/bundler.ts
@@ -1,0 +1,128 @@
+import { PackedUserOpJson } from '../models/MultiSigs'
+import { PackedUserOp, userOpToJson } from './userOp'
+
+// Thin JSON-RPC wrapper around the ERC-4337 bundler methods. The app
+// intentionally avoids pulling in `viem/account-abstraction` so the codec
+// stays explicit and the dep surface is contained; a bundler is just a JSON
+// endpoint that speaks a handful of extra methods on top of the standard
+// Ethereum JSON-RPC.
+
+export type UserOpReceiptJson = {
+  userOpHash: `0x${string}`
+  sender: `0x${string}`
+  nonce: string
+  paymaster?: `0x${string}`
+  actualGasCost: string
+  actualGasUsed: string
+  success: boolean
+  reason?: string
+  receipt: {
+    blockHash: `0x${string}`
+    blockNumber: `0x${string}`
+    transactionHash: `0x${string}`
+    logs: unknown[]
+  }
+}
+
+export type UserOpGasEstimation = {
+  callGasLimit: string
+  verificationGasLimit: string
+  preVerificationGas: string
+  paymasterAndData?: `0x${string}`
+}
+
+export class BundlerRpcError extends Error {
+  readonly code: number
+  readonly data: unknown
+  constructor(message: string, code: number, data: unknown) {
+    super(message)
+    this.code = code
+    this.data = data
+  }
+}
+
+const rpcCall = async <T>(url: string, method: string, params: unknown[]): Promise<T> => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })
+  })
+  if (!response.ok) throw new Error(`Bundler ${method} failed: HTTP ${response.status}`)
+  const body = (await response.json()) as { result?: T; error?: { message?: string; code?: number; data?: unknown } }
+  if (body.error != null) {
+    throw new BundlerRpcError(
+      body.error.message ?? `Bundler ${method} rejected`,
+      body.error.code ?? -32000,
+      body.error.data
+    )
+  }
+  if (body.result == null) throw new Error(`Bundler ${method} returned no result`)
+  return body.result
+}
+
+export const supportedEntryPoints = async (bundlerUrl: string): Promise<`0x${string}`[]> =>
+  rpcCall<`0x${string}`[]>(bundlerUrl, 'eth_supportedEntryPoints', [])
+
+export const sendUserOperation = async (
+  bundlerUrl: string,
+  op: PackedUserOp,
+  entryPoint: `0x${string}`
+): Promise<`0x${string}`> => rpcCall<`0x${string}`>(bundlerUrl, 'eth_sendUserOperation', [userOpToJson(op), entryPoint])
+
+export const estimateUserOperationGas = async (
+  bundlerUrl: string,
+  op: PackedUserOp,
+  entryPoint: `0x${string}`
+): Promise<UserOpGasEstimation> =>
+  rpcCall<UserOpGasEstimation>(bundlerUrl, 'eth_estimateUserOperationGas', [
+    { ...userOpToJson(op), signature: '0x' },
+    entryPoint
+  ])
+
+export const getUserOperationByHash = async (
+  bundlerUrl: string,
+  hash: `0x${string}`
+): Promise<UserOpReceiptJson | null> =>
+  rpcCall<UserOpReceiptJson | null>(bundlerUrl, 'eth_getUserOperationByHash', [hash])
+
+export const getUserOperationReceipt = async (
+  bundlerUrl: string,
+  hash: `0x${string}`
+): Promise<UserOpReceiptJson | null> =>
+  rpcCall<UserOpReceiptJson | null>(bundlerUrl, 'eth_getUserOperationReceipt', [hash])
+
+export const waitForUserOperationReceipt = async (
+  bundlerUrl: string,
+  hash: `0x${string}`,
+  { timeout = 120_000, interval = 2_000 }: { timeout?: number; interval?: number } = {}
+): Promise<UserOpReceiptJson> => {
+  const deadline = Date.now() + timeout
+   
+  while (true) {
+    const receipt = await getUserOperationReceipt(bundlerUrl, hash)
+    if (receipt != null) return receipt
+    if (Date.now() > deadline) throw new Error(`Bundler receipt for ${hash} did not arrive within ${timeout}ms`)
+    await new Promise((resolve) => setTimeout(resolve, interval))
+  }
+}
+
+// Convenience: validate the userOpJson shape against the canonical PackedUserOp
+// tuple so dev-time mistakes surface early.
+export const assertUserOpJsonShape = (value: unknown): PackedUserOpJson => {
+  if (typeof value !== 'object' || value === null) throw new Error('userOpJson must be an object')
+  const rec = value as Record<string, unknown>
+  for (const key of [
+    'sender',
+    'nonce',
+    'initCode',
+    'callData',
+    'accountGasLimits',
+    'preVerificationGas',
+    'gasFees',
+    'paymasterAndData',
+    'signature'
+  ]) {
+    if (typeof rec[key] !== 'string') throw new Error(`userOpJson.${key} must be a hex string`)
+  }
+  return rec as unknown as PackedUserOpJson
+}

--- a/src/utils/decodeContractError.ts
+++ b/src/utils/decodeContractError.ts
@@ -57,7 +57,22 @@ const ERROR_MESSAGES: Record<string, string> = {
   NotEntryPoint: 'Only the ERC-4337 EntryPoint can call this function.',
   InvalidNonce: 'The transaction nonce does not match the wallet’s current nonce.',
   BatchCallFailed: 'A step of the atomic batch failed, so the whole batch reverted.',
-  MessageNotSigned: 'This message was never signed by the wallet.'
+  MessageNotSigned: 'This message was never signed by the wallet.',
+  // EntryPoint v0.7 custom errors (the bundler surfaces these when the
+  // UserOp fails inside handleOps).
+  FailedOp:
+    'The bundler refused the UserOperation. Read the bundled transaction’s revert reason for the exact failure.',
+  FailedOpWithRevert: 'The bundler refused the UserOperation and included the inner revert reason.',
+  SignatureValidationFailed: 'The collected owner signatures do not satisfy the wallet’s threshold.',
+  InvalidSender: 'The UserOp’s sender is not a deployed smart account on this EntryPoint.',
+  InvalidPaymaster: 'The UserOp’s paymasterAndData is not a valid paymaster for this EntryPoint.',
+  PaymasterDepositTooLow: 'The paymaster has insufficient deposit to cover this UserOp’s gas.',
+  PaymasterAndDataEmpty: 'The paymaster stub rejected the op — paymasterAndData is empty.',
+  SenderAddressMismatch: 'The address recovered from initCode does not match the UserOp sender.',
+  InvalidAccount: 'The wallet does not recognise the UserOp sender.',
+  ReentrancyGuard: 'A re-entrant call to the EntryPoint was blocked.',
+  EntryPointInsufficientBalance: 'The wallet has no EntryPoint deposit to pay for this UserOp.',
+  BundlerRejected: 'The bundler rejected the UserOperation before submission.'
 }
 
 // Extracts a human-readable reason from a wagmi/viem contract error, decoding

--- a/src/utils/paymaster.ts
+++ b/src/utils/paymaster.ts
@@ -1,0 +1,48 @@
+import { PackedUserOp, userOpToJson } from './userOp'
+
+// Pimlico-style paymaster client. The endpoint is a JSON-RPC service that
+// fronts `pm_getPaymasterData`. If no paymasterUrl is configured, the
+// caller falls back to the wallet's own EntryPoint deposit (paymasterAndData
+// = '0x') and the bundler/EntryPoint handles the prefund.
+
+export type PaymasterData = {
+  paymasterAndData: `0x${string}`
+  // Some paymasters also return updated gas estimates; the caller may apply
+  // them to the UserOp before sending.
+  callGasLimit?: string
+  preVerificationGas?: string
+  verificationGasLimit?: string
+}
+
+export type PmGetPaymasterDataParams = {
+  userOp: PackedUserOp
+  entryPoint: `0x${string}`
+  // Pimlico's optional context: sponsorship policy id, token address for
+  // ERC-20 paymasters, etc. Forwarded verbatim.
+  context?: Record<string, unknown>
+}
+
+const rpcCall = async <T>(url: string, method: string, params: unknown[]): Promise<T> => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })
+  })
+  if (!response.ok) throw new Error(`Paymaster ${method} failed: HTTP ${response.status}`)
+  const body = (await response.json()) as { result?: T; error?: { message?: string; code?: number; data?: unknown } }
+  if (body.error != null) {
+    throw new Error(body.error.message ?? `Paymaster ${method} rejected`)
+  }
+  if (body.result == null) throw new Error(`Paymaster ${method} returned no result`)
+  return body.result
+}
+
+export const pmGetPaymasterData = async (
+  paymasterUrl: string,
+  params: PmGetPaymasterDataParams
+): Promise<PaymasterData> => {
+  const { userOp, entryPoint, context } = params
+  const args: unknown[] = [{ ...userOpToJson(userOp), signature: '0x' }, entryPoint]
+  if (context != null) args.push(context)
+  return rpcCall<PaymasterData>(paymasterUrl, 'pm_getPaymasterData', args)
+}

--- a/src/utils/userOp.ts
+++ b/src/utils/userOp.ts
@@ -1,0 +1,177 @@
+import { encodeAbiParameters, encodeFunctionData, getAddress, toHex, trim, type Hex } from 'viem'
+
+import { PackedUserOpJson, UserOpGas } from '../models/MultiSigs'
+import { combineSignatures } from './signatureBlob'
+
+// Minimal ABI for the wallet's `execute(to, value, data)` entry point. The
+// full Extended ABI is JSON-typed and viem's encodeFunctionData is happiest
+// with a const tuple, so we redeclare the one entry point we need here.
+const WALLET_EXECUTE_ABI = [
+  {
+    type: 'function',
+    name: 'execute',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'data', type: 'bytes' }
+    ],
+    outputs: []
+  }
+] as const
+
+// PackedUserOperation helpers for the 0.5.0 Extended wallet's ERC-4337 v0.7
+// surface. The wallet's `execute(to, value, data)` (EntryPoint-only) is the
+// only call shape the account accepts on the UserOp path.
+
+export const ZERO_BYTES32 = '0x0000000000000000000000000000000000000000000000000000000000000000' as const
+export const EMPTY_PAYMASTER_AND_DATA = '0x' as const
+
+// Sane Sepolia-friendly defaults. Wallets can override these per request so
+// gas estimation can refine them later.
+export const DEFAULT_USEROP_GAS: UserOpGas = {
+  verificationGasLimit: '180000',
+  callGasLimit: '200000',
+  preVerificationGas: '50000',
+  maxFeePerGas: '2000000000',
+  maxPriorityFeePerGas: '1000000000'
+}
+
+export const encodeUserOpCallData = ({
+  wallet: _wallet,
+  to,
+  value,
+  data
+}: {
+  wallet: `0x${string}`
+  to: `0x${string}`
+  value: bigint
+  data: `0x${string}`
+}): `0x${string}` =>
+  encodeFunctionData({
+    abi: WALLET_EXECUTE_ABI,
+    functionName: 'execute',
+    args: [to, value, data]
+  }) as `0x${string}`
+
+export type PackedUserOp = {
+  sender: `0x${string}`
+  nonce: bigint
+  initCode: `0x${string}`
+  callData: `0x${string}`
+  accountGasLimits: `0x${string}`
+  preVerificationGas: bigint
+  gasFees: `0x${string}`
+  paymasterAndData: `0x${string}`
+  signature: `0x${string}`
+}
+
+// The two packed-bytes32 gas fields of the v0.7 PackedUserOperation.
+export const packAccountGasLimits = ({
+  verificationGasLimit,
+  callGasLimit
+}: Pick<UserOpGas, 'verificationGasLimit' | 'callGasLimit'>): `0x${string}` => {
+  const verify = BigInt(verificationGasLimit)
+  const call = BigInt(callGasLimit)
+  const hi = (verify >> 128n) & 0xffffffffffffffffffffffffffffffffn
+  const lo = verify & 0xffffffffffffffffffffffffffffffffn
+  return ((hi << 128n) | call).toString(16).padStart(64, '0').replace(/^/, '0x') as `0x${string}`
+}
+
+export const packGasFees = ({
+  maxPriorityFeePerGas,
+  maxFeePerGas
+}: Pick<UserOpGas, 'maxPriorityFeePerGas' | 'maxFeePerGas'>): `0x${string}` => {
+  const priority = BigInt(maxPriorityFeePerGas)
+  const max = BigInt(maxFeePerGas)
+  return ((priority << 128n) | (max & 0xffffffffffffffffffffffffffffffffn))
+    .toString(16)
+    .padStart(64, '0')
+    .replace(/^/, '0x') as `0x${string}`
+}
+
+export const unpackAccountGasLimits = (
+  packed: `0x${string}`
+): { verificationGasLimit: bigint; callGasLimit: bigint } => {
+  const raw = BigInt(packed)
+  const mask = (1n << 128n) - 1n
+  return { verificationGasLimit: (raw >> 128n) & mask, callGasLimit: raw & mask }
+}
+
+export const unpackGasFees = (packed: `0x${string}`): { maxPriorityFeePerGas: bigint; maxFeePerGas: bigint } => {
+  const raw = BigInt(packed)
+  const mask = (1n << 128n) - 1n
+  return { maxPriorityFeePerGas: (raw >> 128n) & mask, maxFeePerGas: raw & mask }
+}
+
+export const buildPackedUserOp = ({
+  sender,
+  nonce,
+  initCode = '0x',
+  callData,
+  gas,
+  paymasterAndData = EMPTY_PAYMASTER_AND_DATA,
+  signature = '0x'
+}: {
+  sender: `0x${string}`
+  nonce: bigint
+  initCode?: `0x${string}`
+  callData: `0x${string}`
+  gas: UserOpGas
+  paymasterAndData?: `0x${string}`
+  signature?: `0x${string}`
+}): PackedUserOp => ({
+  sender,
+  nonce,
+  initCode,
+  callData,
+  accountGasLimits: packAccountGasLimits(gas),
+  preVerificationGas: BigInt(gas.preVerificationGas),
+  gasFees: packGasFees(gas),
+  paymasterAndData,
+  signature
+})
+
+const bigintToHex = (value: bigint): `0x${string}` => toHex(value)
+const hexToBigint = (value: string): bigint => BigInt(value || '0x0')
+
+export const userOpToJson = (op: PackedUserOp): PackedUserOpJson => ({
+  sender: getAddress(op.sender),
+  nonce: bigintToHex(op.nonce),
+  initCode: trim(op.initCode as Hex) ?? '0x',
+  callData: trim(op.callData as Hex) ?? '0x',
+  accountGasLimits: trim(op.accountGasLimits as Hex) ?? ZERO_BYTES32,
+  preVerificationGas: bigintToHex(op.preVerificationGas),
+  gasFees: trim(op.gasFees as Hex) ?? ZERO_BYTES32,
+  paymasterAndData: trim(op.paymasterAndData as Hex) ?? '0x',
+  signature: trim(op.signature as Hex) ?? '0x'
+})
+
+export const userOpFromJson = (op: PackedUserOpJson): PackedUserOp => ({
+  sender: getAddress(op.sender),
+  nonce: hexToBigint(op.nonce),
+  initCode: (op.initCode || '0x') as `0x${string}`,
+  callData: (op.callData || '0x') as `0x${string}`,
+  accountGasLimits: (op.accountGasLimits || ZERO_BYTES32) as `0x${string}`,
+  preVerificationGas: hexToBigint(op.preVerificationGas),
+  gasFees: (op.gasFees || ZERO_BYTES32) as `0x${string}`,
+  paymasterAndData: (op.paymasterAndData || '0x') as `0x${string}`,
+  signature: (op.signature || '0x') as `0x${string}`
+})
+
+// The wallet's `validateUserOp` consumes the same `(owner, sig)[]` blob as
+// `execTransaction`, so the existing combinator is the single source of truth.
+export const packUserOpSignatures = (
+  walletVersion: string | undefined,
+  ownerSigners: string[],
+  signatures: string[]
+): `0x${string}` => combineSignatures(walletVersion, ownerSigners, signatures)
+
+// The EIP-712-ish types used by Pimlico's `pm_getPaymasterData`. Some
+// paymaster providers accept a `context` blob (token, sponsorship policy,
+// ...); we forward it verbatim.
+export const encodePaymasterContext = (context: Record<string, unknown>): `0x${string}` =>
+  encodeAbiParameters(
+    [{ type: 'bytes' }],
+    [`0x${Buffer.from(JSON.stringify(context)).toString('hex')}` as `0x${string}`]
+  )


### PR DESCRIPTION
## What

The `AccountAbstractionPanel` was marketing + `depositTo` only. The 0.5.0 Extended wallet is a real ERC-4337 v0.7 IAccount (`validateUserOp`, `userOpSigningHash`, EntryPoint-only `execute(to, value, data)`), so the contract surface was already there — the app just had no flow on top of it.

This PR closes the gap with a build → collect-sigs → send-to-bundler pipeline:

- **Build**: `PackedUserOperation` with `callData = wallet.execute(to, value, data)`, gas packed into the two bytes32 fields, EntryPoint 2D nonce read from `getNonce(sender, 192)`.
- **Sign (off-chain ECDSA)**: owners `personal_sign` the *inner* `userOpHash`. The signature is over `EIP191(userOpHash) = userOpSigningHash`, which is what `_checkSignatures` in `validateUserOp` recovers from. Votes accumulate in the same `(owner, sig)[]` blob the classic path uses.
- **Approve on-chain**: `wallet.approveHash(userOpSigningHash)`; the detail view reads `getApprovedOwners(userOpSigningHash)` and counts it alongside the ECDSA votes.
- **Send to bundler**: configurable URL per chain (env var `NEXT_PUBLIC_BUNDLER_URL_<chainId>` + global fallback, plus per-chain override in localStorage). The hook optionally calls `pm_getPaymasterData`, refines gas via `eth_estimateUserOperationGas`, sends, then polls `eth_getUserOperationReceipt`. The bundled tx hash is linked to the chain's explorer.
- **Paymaster**: included in v1 via Pimlico-style `pm_getPaymasterData`. Optional toggle (env var + per-chain override).
- **EntryPoint deposit**: existing `depositTo`, plus a new `withdrawTo(recipient, amount)` form for the owner.
- **Storage**: reuses the existing `multisig_requests` JSONB; new fields `mode: 'userop'`, `userOpHash`, `userOpSigningHash`, `userOpJson`, `userOpReceipt`, `bundlerUrl`, `paymasterUrl`. No schema migration.

## UI

- **`AccountAbstractionPanel`**: stale-copy fix ("UserOperations use the EntryPoint's 2D nonce…"), EntryPoint nonce readout, bundler + paymaster URL fields, withdraw form.
- **`CreateMultiSigRequestForm`**: "Submit via bundler (ERC-4337)" toggle. When enabled: hides EIP-712-only fields (validUntil / operation / pinned nonce), disables batch + DELEGATECALL (the wallet's `execute` entry can't carry a multiRequest sequence), and routes signing to `SignUserOp`.
- **`MultiSigRequestDetail`**: branches on `request.mode === 'userop'` and renders the dedicated `UserOpRequestCard` (userOpHash, userOpSigningHash, EntryPoint nonce, on-chain approvers, send-to-bundler CTA, bundled tx hash + status). The classic multisig card is untouched.

## New files

- src/utils/userOp.ts · src/utils/bundler.ts · src/utils/paymaster.ts
- src/states/bundlerConfig.ts
- src/hooks/useEntryPointNonce.ts · useUserOpSigning.ts · useSendUserOp.ts · useUserOpReceipt.ts · useApproveUserOpHash.ts · useRevokeUserOpHash.ts · useUserOpApprovalState.ts
- src/components/buttons/SignUserOp{,.stories}.tsx · SubmitUserOpRequest{,.stories}.tsx · ApproveUserOpRequest{,.stories}.tsx · RevokeUserOpApproval{,.stories}.tsx
- src/components/multiSigDetails/UserOpRequestCard{,.stories}.tsx

## Modified files

- src/constants/abi/entryPoint.ts — extend a minimal ABI with `getNonce`, `getUserOpHash`, `getDepositInfo`, `withdrawTo`, `handleOps`.
- src/models/MultiSigs.ts — add `PackedUserOpJson`, `UserOpGas`, `UserOpReceipt`, and the request-level `mode` / `userOp*` fields.
- src/hooks/useEntryPointDeposit.ts — add `withdrawTo`.
- src/utils/decodeContractError.ts — EntryPoint v0.7 custom error copy.
- src/components/multiSigDetails/AccountAbstractionPanel.tsx · MultiSigRequestDetail.tsx · CreateMultiSigRequestForm.tsx — wire the new flow.
- docs/PRD-contract-feature-parity.md — Epic G + delivery row.
- .env.example / .env.sample — NEXT_PUBLIC_BUNDLER_URL / _PAYMASTER_URL.

## Verification

- `yarn build` is green (the real lint gate per project memory).
- Local sanity on Sepolia with a 0.5.0 Extended wallet + a Pimlico or Stackup bundler URL:
  1. Settings → Account abstraction → paste the bundler URL; confirm EntryPoint deposit + nonce readouts populate.
  2. Build a request → toggle "Submit via bundler (ERC-4337)" → small ETH transfer.
  3. Sign from one owner (personal_sign over the EntryPoint userOpHash).
  4. From a second owner, sign again; threshold flips satisfied.
  5. Press Send to bundler → receipt status flips pending → mined; bundled tx hash links to Etherscan; recipient balance increases.
  6. Repeat with on-chain `approveHash(userOpSigningHash)` instead of personal_sign for one vote.
  7. Repeat with a Pimlico paymaster URL configured; `paymasterAndData` is populated and the wallet's deposit is **not** debited.

## Out of scope

- Gas price oracle / auto-tuning (viem `estimateFeesPerGas` or the bundler's estimator suffices).
- Multi-bundler failover.
- `eth_simulateUserOpAssetChanges` preview.
- Paymaster sponsor signing (the Pimlico `pm_getPaymasterData` flow returns an unsigned blob; signing it on behalf of a real paymaster is a later iteration).
- Per-step `multiRequest` results on the UserOp path (the inner `execute(to, value, data)` only carries the URL-encoded `execute` call; per-step results would require a new wallet event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)