### PR TITLE
fix(detail): refetch request details when Zustand store updates (#69)

### DIFF
--- a/src/hooks/useMultiSigRequestDetails.ts
+++ b/src/hooks/useMultiSigRequestDetails.ts
@@ -10,18 +10,25 @@ const useMultiSigRequestDetails = (multiSigRequestId: string) => {
   const chains = useChains()
   const chain = chains.find((c) => c.id === chainId)
   const { address } = useAccount()
-  const [dataIsLoading, setDataIsLoading] = useState(false)
   const [requestDetails, setRequestDetails] = useState<MultiSigTransactionRequest | null>(null)
   const { multiSigTransactionRequests } = useMultiSigs()
 
+  // Refetch whenever the Zustand store updates (sign / execute / reset / delete
+  // all patch `multiSigTransactionRequests`) so the detail view re-renders.
+  // An earlier version gated this behind a `dataIsLoading` flag that was set
+  // to true on the first run and never reset, which prevented every
+  // subsequent refetch — see issue #69.
   useEffect(() => {
-    if (chain && !dataIsLoading && address) {
-      setDataIsLoading(true)
-      getMultiSigRequestById(multiSigRequestId).then((data) => {
-        if (data && data.content) setRequestDetails(data.content[0])
-      })
+    if (!chain || !address) return
+    let cancelled = false
+    getMultiSigRequestById(multiSigRequestId).then((data) => {
+      if (cancelled) return
+      if (data && data.content) setRequestDetails(data.content[0])
+    })
+    return () => {
+      cancelled = true
     }
-  }, [multiSigTransactionRequests, dataIsLoading, chain, address, multiSigRequestId])
+  }, [multiSigTransactionRequests, chain, address, multiSigRequestId])
 
   return requestDetails
 }


### PR DESCRIPTION
Closes #69

## What

`useMultiSigRequestDetails` set a `dataIsLoading` flag to true on its first run and never cleared it. The flag was also in the effect's dep array, so the effect never re-fired after that first call — even though `multiSigTransactionRequests` (Zustand) updates on every sign / execute / reset / delete. The detail view silently went stale.

## Fix

- Drop the stale `dataIsLoading` gate (the consumer renders `null` while `requestDetails` is null, so a separate loading flag isn't needed).
- Refetch on every relevant dep change (`multiSigTransactionRequests`, `chain`, `address`, `multiSigRequestId`).
- Add a `cancelled` flag so an in-flight response can't overwrite a fresher one when the effect re-runs.

## Verified

- `yarn build` — green
- `eslint --fix` (lint-staged) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)